### PR TITLE
Search By Tag returns console errors when input is not defined

### DIFF
--- a/Assets/AltTester/Runtime/Commands/FindObject/PathSelector.cs
+++ b/Assets/AltTester/Runtime/Commands/FindObject/PathSelector.cs
@@ -209,7 +209,13 @@ namespace AltTester.AltTesterUnitySDK.Commands
                 case PropertyType.name:
                     return gameObjectToCheck.name.Equals(PropertyValue) ? gameObjectToCheck : null;
                 case PropertyType.tag:
-                    return gameObjectToCheck.CompareTag(PropertyValue) ? gameObjectToCheck : null;
+                    try
+                    {
+                        return gameObjectToCheck.tag.Equals(PropertyValue) ? gameObjectToCheck : null;
+                    }catch(Exception)
+                    {
+                        return null;
+                    }
                 case PropertyType.layer:
                     int layerId = LayerMask.NameToLayer(PropertyValue);
                     return gameObjectToCheck.layer.Equals(layerId) ? gameObjectToCheck : null;


### PR DESCRIPTION
@RobertPoienar @ReichEdvin @robert-altom @rucindrea @SandyEma9 