### PR TITLE
[Documentation] Add note for deprecated DesiredCapabilities with Selenium 4

### DIFF
--- a/Docs/source/pages/alttester-with-appium.md
+++ b/Docs/source/pages/alttester-with-appium.md
@@ -52,7 +52,10 @@ The script will install any requirements that are missing from your machine (exc
 
    Please observe the following about the setup method in **base_test.py**:
 
-   1. A minimum amount of desired capabilities have to be set in order for Appium to work. More details about desired capabilities can be found in the official `Appium documentation <https://appium.io/docs/en/2.0/index.html>`_
-   2. The Appium driver needs to be created before the reverse port forwarding needed by AltTester Unity SDK is done. This is because Appium clears any other reverse port forwarding when it starts.
+   1. A minimum amount of capabilities have to be set in order for Appium to work. More details about capabilities can be found in the official `Appium documentation <https://appium.io/docs/en/2.0/guides/caps/>`_
+   
+   2. Starting with **Selenium 4** the *DesiredCapabilities* are deprecated and the Webdriver now uses *Options* to pass capabilities, so if you're using Selenium 4, in order for the example project to work, you may have to update the code with the new setup - see the `Selenium documentation <https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/>`_
+   
+   3. The Appium driver needs to be created before the reverse port forwarding needed by AltTester Unity SDK is done. This is because Appium clears any other reverse port forwarding when it starts.
 
 ```

--- a/Docs/source/pages/examples.md
+++ b/Docs/source/pages/examples.md
@@ -10,26 +10,24 @@ We plan to add more examples in the near future.
 
 ```
 
+```eval_rst
+.. note::
+
+   Starting with **Selenium 4** the *DesiredCapabilities* are deprecated and the Webdriver now uses *Options* to pass capabilities, so if you're using Selenium 4, in order for the example projects that use Appium to work, you may have to update the code with the new setup - see the `Selenium documentation <https://www.selenium.dev/documentation/webdriver/getting_started/upgrade_to_selenium_4/>`_
+
+```
+
 **1.** Example test projects created for different languages and platforms:
 * C# tests [Standalone (NuGetPackage)](https://github.com/alttester/EXAMPLES-CSharp-Standalone-AltTrashCat)  | [Android](https://github.com/alttester/EXAMPLES-CSharp-Android-AltTrahCat) | [iOS](https://github.com/alttester/EXAMPLES-CSharp-iOS-AltTrahCat)
 * Python tests [Standalone](https://github.com/alttester-test-examples/Python-Standalone-AltTrashCat) | [Android](https://github.com/alttester-test-examples/Python-Android-AltTrashCat) | [iOS](https://github.com/alttester-test-examples/Python-iOS-AltTrashCat)
-* Python tests [Android with Appium](https://github.com/alttester/EXAMPLES-Python-Android-with-Appium-AltTrashCat) | [Standalone](https://github.com/alttester/EXAMPLES-Python-Standalone-AltTrashCat) | [Android](https://github.com/alttester/EXAMPLES-Python-Android-AltTrashCat) | [iOS](https://github.com/alttester/EXAMPLES-Python-iOS-AltTrashCat)
- * Java tests [Standalone](https://github.com/alttester-test-examples/Java-Standalone-and-Android-AltTrashCat) | [Android](https://github.com/alttester-test-examples/Java-Standalone-and-Android-AltTrashCat) | [iOS](https://github.com/alttester-test-examples/Java-iOS-AltTrashCat)
-* Java tests [Standalone](https://github.com/alttester/EXAMPLES-Java-Standalone-and-Android-AltTrashCat) | [Android](https://github.com/alttester/EXAMPLES-Java-Standalone-and-Android-AltTrashCat)| [iOS](https://github.com/alttester/EXAMPLES-Java-iOS-AltTrashCat)
+* Python tests [Android with Appium](https://github.com/alttester/EXAMPLES-Python-Android-with-Appium-AltTrashCat)
+* Java tests [Standalone](https://github.com/alttester/EXAMPLES-Java-Standalone-and-Android-AltTrashCat) | [Android](https://github.com/alttester/EXAMPLES-Java-Standalone-and-Android-AltTrashCat) | [iOS](https://github.com/alttester/EXAMPLES-Java-iOS-AltTrashCat)
 
     You can get the sample app from the [Unity Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/endless-runner-sample-game-87901).
 
 <!-- **2.** Example test project for multiplayer features:
 
 * Python tests [Multiplayer iOS / Android](https://github.com/alttester-test-examples/Python-Android-iOS-Multiplayer--AltTanks) -->
-
-<!--
-**3.** Example test project for AltUnity Pro Alpha:
-
-* C# tests [WebGL](https://gitlab.com/altom/altunity/examples/altunity-pro-alpha-example)
-
-    You can get the sample app from the [Unity Asset Store](https://assetstore.unity.com/packages/essentials/tutorial-projects/tanks-tutorial-46209).
- -->
 
 **2.** Example test project for AltTester Unity SDK:
 


### PR DESCRIPTION
In this PR:
- Added the required note in _Examples_ and _Running tests together with Appium_ > _AltTester Unity SDK with Appium example_ sections
- Removed duplicate entries in the _Examples_ section