### PR TITLE
Fix proxy finder when using http/https socks proxy

### DIFF
--- a/Assets/AltTester/Runtime/AltDriver/Proxy/Plugins/iOS/ProxyFinder/Source/ProxyFinder.swift
+++ b/Assets/AltTester/Runtime/AltDriver/Proxy/Plugins/iOS/ProxyFinder/Source/ProxyFinder.swift
@@ -59,14 +59,14 @@ import JavaScriptCore
         if let httpSEnable = systemProxySettings["HTTPSEnable"] as? Int, httpSEnable == 1,
            destinationUrl.starts(with: "https") {
             if let host = systemProxySettings["HTTPSProxy"] as? String,
-               let port = systemProxySettings["HTTPSPort"] as? String {
+               let port = systemProxySettings["HTTPSPort"] as? Int {
                 return "https://\(host):\(port)"
             }
         }
 
         if let httpEnable = systemProxySettings["HTTPEnable"] as? Int, httpEnable == 1 {
             if let host = systemProxySettings["HTTPProxy"] as? String,
-               let port = systemProxySettings["HTTPPort"] as? String {
+               let port = systemProxySettings["HTTPPort"] as? Int {
                 return "http://\(host):\(port)"
             }
         }


### PR DESCRIPTION
As per documentation from https://developer.apple.com/documentation/cfnetwork/global_proxy_settings_constants, HTTPPort and HTTPSPort are CFNumber and not CFString. 

This fixes detection of proxy when not using PAC.