### PR TITLE
Fix XML report and use correct NUnit tag

### DIFF
--- a/Assets/AltTester/Editor/Scripts/AltTestRunner.cs
+++ b/Assets/AltTester/Editor/Scripts/AltTestRunner.cs
@@ -59,7 +59,7 @@ namespace AltTester.AltTesterUnitySDK.Editor
             var testAssemblyRunner = new NUnit.Framework.Api.NUnitTestAssemblyRunner(new NUnit.Framework.Api.DefaultTestAssemblyBuilder());
             progress = 0;
             total = filters.Filters.Count;
-            TNode xmlContent = new TNode("Test");
+            TNode xmlContent = new TNode("test-run");
             foreach (var assembly in assemblies)
             {
                 if (!assemblyList.Contains(assembly.GetName().Name))
@@ -511,7 +511,7 @@ namespace AltTester.AltTesterUnitySDK.Editor
             var Tests = new List<string>();
             var AssemblyToTest = new List<string>();
             var filter = new NUnit.Framework.Internal.Filters.OrFilter();
-            TNode xmlContent = new TNode("Test");
+            TNode xmlContent = new TNode("test-run");
             var testAssemblyRunner = new NUnit.Framework.Api.NUnitTestAssemblyRunner(new NUnit.Framework.Api.DefaultTestAssemblyBuilder());
             NUnit.Framework.Interfaces.ITestListener listener = new AltTestRunListener(null);
             System.Reflection.Assembly[] assemblies = System.AppDomain.CurrentDomain.GetAssemblies();


### PR DESCRIPTION
The `test-run` is the correct NUnit 3 tag to use in the XML report, to replace the `test` one we currently use. 

I've tried to process a report with tests in 2 different namespaces with Jenkins XUnit plugin with Nunit 3 selected, and it works correctly:
![image](https://github.com/alttester/AltTester-Unity-SDK/assets/3305864/7b049856-9b34-4cfe-a735-54a75ee485a0)
