### PR TITLE
[API] Move appName after port in the AltDriver class list of parameters

### DIFF
--- a/Docs/source/pages/commands.md
+++ b/Docs/source/pages/commands.md
@@ -12,11 +12,11 @@ An AltDriver instance will connect to the running instrumented Unity application
 
 | Name           | Type    | Required | Description                                                                           |
 | -------------- | ------- | -------- | ------------------------------------------------------------------------------------- |
-| host           | string  | No       | The IP or hostname AltTester® Unity SDK is listening on. The default value is "127.0.0.1". |
-| port           | int     | No       | The default value is 13000.                                                           |
-| enableLogging  | boolean | No       | The default value is false.                                                           |
-| connectTimeout | int     | No       | The connect timeout in seconds. The default value is 60.                                |
+| host           | string  | No       | The IP or hostname AltTester® Unity SDK is listening on. The default value is `127.0.0.1`. |
+| port           | int     | No       | The default value is `13000`.                                                              |
 | appName        | string  | No       | The name of the Unity application. The default value is `__default__`.                  |
+| enableLogging  | boolean | No       | The default value is `false`.                                                           |
+| connectTimeout | int     | No       | The connect timeout in seconds. The default value is `60`.                              |
 | platform       | string  | No       | The platform of the Unity application. The default value is `unknown`.                  |
 | platformVersion| string  | No       | The platform version of the Unity application. The default value is `unknown`.          |
 | deviceInstanceId| string  | No      | The device instance id of the Unity application. The default value is`unknown`.         |


### PR DESCRIPTION
Moved `appName` param after `port` param