### PR TITLE
1517 setup pipeline for parallel runs on net tests

### DIFF
--- a/Assets/AltTester/Runtime/AltDriver/AltDriver.cs
+++ b/Assets/AltTester/Runtime/AltDriver/AltDriver.cs
@@ -65,7 +65,7 @@ namespace AltTester.AltTesterUnitySDK.Driver
                 }
 
                 logger.Debug(
-                    "Connecting to AltTester on host: '{0}', port: '{1}', appName: '{2}', platform: '{3}', platformVersion: '{4}', deviceInstanceId: '{5}' and driverType: '{6}'.",
+                    "Connecting to AltTester® on host: '{0}', port: '{1}', appName: '{2}', platform: '{3}', platformVersion: '{4}', deviceInstanceId: '{5}' and driverType: '{6}'.",
                     host,
                     port,
                     appName,

--- a/Assets/AltTester/Runtime/AltDriver/AltDriver.cs
+++ b/Assets/AltTester/Runtime/AltDriver/AltDriver.cs
@@ -34,6 +34,7 @@ namespace AltTester.AltTesterUnitySDK.Driver
     {
         private static readonly NLog.Logger logger = DriverLogManager.Instance.GetCurrentClassLogger();
         private readonly IDriverCommunication communicationHandler;
+        private static object driverLock = new object();
         public static readonly string VERSION = "2.1.0";
 
         public IDriverCommunication CommunicationHandler { get { return communicationHandler; } }
@@ -48,33 +49,36 @@ namespace AltTester.AltTesterUnitySDK.Driver
         /// <param name="appName">The name of the Unity application.</param>
         public AltDriver(string host = "127.0.0.1", int port = 13000, string appName = "__default__", bool enableLogging = false, int connectTimeout = 60, string platform = "unknown", string platformVersion = "unknown", string deviceInstanceId = "unknown", string appId = "unknown", string driverType = "SDK")
         {
+            lock (driverLock)
+            {
 #if UNITY_EDITOR || ALTTESTER
             var defaultLevels = new Dictionary<AltLogger, AltLogLevel> { { AltLogger.File, AltLogLevel.Debug }, { AltLogger.Unity, AltLogLevel.Debug } };
 #else
-            var defaultLevels = new Dictionary<AltLogger, AltLogLevel> { { AltLogger.File, AltLogLevel.Debug }, { AltLogger.Console, AltLogLevel.Debug } };
+                var defaultLevels = new Dictionary<AltLogger, AltLogLevel> { { AltLogger.File, AltLogLevel.Debug }, { AltLogger.Console, AltLogLevel.Debug } };
 #endif
 
-            DriverLogManager.SetupAltDriverLogging(defaultLevels);
+                DriverLogManager.SetupAltDriverLogging(defaultLevels);
 
-            if (!enableLogging)
-            {
-                DriverLogManager.StopLogging();
+                if (!enableLogging)
+                {
+                    DriverLogManager.StopLogging();
+                }
+
+                logger.Debug(
+                    "Connecting to AltTester on host: '{0}', port: '{1}', appName: '{2}', platform: '{3}', platformVersion: '{4}', deviceInstanceId: '{5}' and driverType: '{6}'.",
+                    host,
+                    port,
+                    appName,
+                    platform,
+                    platformVersion,
+                    deviceInstanceId,
+                    driverType
+                );
+                communicationHandler = new DriverCommunicationHandler(host, port, connectTimeout, appName, platform, platformVersion, deviceInstanceId, appId, driverType);
+                communicationHandler.Connect();
+
+                checkServerVersion();
             }
-
-            logger.Debug(
-                "Connecting to AltTester® on host: '{0}', port: '{1}', appName: '{2}', platform: '{3}', platformVersion: '{4}', deviceInstanceId: '{5}' and driverType: '{6}'.",
-                host,
-                port,
-                appName,
-                platform,
-                platformVersion,
-                deviceInstanceId,
-                driverType
-            );
-            communicationHandler = new DriverCommunicationHandler(host, port, connectTimeout, appName, platform, platformVersion, deviceInstanceId, appId, driverType);
-            communicationHandler.Connect();
-
-            checkServerVersion();
         }
 
         private void splitVersion(string version, out string major, out string minor)

--- a/Assets/Examples/Test/Editor/Driver/AssemblyInfo.cs
+++ b/Assets/Examples/Test/Editor/Driver/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using NUnit.Framework;
 
-[assembly: Parallelizable(ParallelScope.All)]
+[assembly: Parallelizable(ParallelScope.Fixtures)]
 [assembly: LevelOfParallelism(1)]

--- a/Assets/Examples/Test/Editor/Driver/AssemblyInfo.cs
+++ b/Assets/Examples/Test/Editor/Driver/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using NUnit.Framework;
+
+[assembly: Parallelizable(ParallelScope.All)]
+[assembly: LevelOfParallelism(1)]

--- a/Assets/Examples/Test/Editor/Driver/Commands/AltCommandsTests.cs
+++ b/Assets/Examples/Test/Editor/Driver/Commands/AltCommandsTests.cs
@@ -22,6 +22,8 @@ using NUnit.Framework;
 
 namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
+    [TestFixture]
+    [Parallelizable]
     public class AltCommandsTests
     {
         private AltDriver altDriver;

--- a/Assets/Examples/Test/Editor/Driver/TestDragDemo.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestDragDemo.cs
@@ -1,49 +1,53 @@
 using NUnit.Framework;
 using AltTester.AltTesterUnitySDK.Driver;
 
-public class TestDragDemo : TestBase
+namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
-    public TestDragDemo()
+    [TestFixture]
+    [Parallelizable]
+    public class TestDragDemo : TestBase
     {
-        sceneName = "DragDemo";
-    }
+        public TestDragDemo()
+        {
+            sceneName = "DragDemo";
+        }
 
+        [Test]
+        public void TestMoveLettersWithSwipe()
+        {
+            var holderObject = altDriver.FindObject(By.NAME, "Holder Object (0)");
+            var dragObject = altDriver.FindObject(By.NAME, "0-Object");
+            var initialPosition = dragObject.GetScreenPosition();
+            altDriver.Swipe(dragObject.GetScreenPosition(), holderObject.GetScreenPosition(), 0.3f);
+            var finalPosition = altDriver.FindObject(By.NAME, "0-Object").GetScreenPosition();
+            Assert.That(!initialPosition.Equals(finalPosition));
 
-    [Test]
-    public void TestMoveLettersWithSwipe()
-    {
-        var holderObject = altDriver.FindObject(By.NAME, "Holder Object (0)");
-        var dragObject = altDriver.FindObject(By.NAME, "0-Object");
-        var initialPosition = dragObject.GetScreenPosition();
-        altDriver.Swipe(dragObject.GetScreenPosition(), holderObject.GetScreenPosition(), 0.3f);
-        var finalPosition = altDriver.FindObject(By.NAME, "0-Object").GetScreenPosition();
-        Assert.That(!initialPosition.Equals(finalPosition));
+        }
+        [Test]
+        public void TestMoveLettersWithKeyDownUp()
+        {
+            var holderObject = altDriver.FindObject(By.NAME, "Holder Object (0)");
+            var dragObject = altDriver.FindObject(By.NAME, "0-Object");
+            var initialPosition = dragObject.GetScreenPosition();
+            altDriver.MoveMouse(initialPosition, 0.1f);
+            altDriver.KeyDown(AltKeyCode.Mouse0);
+            altDriver.MoveMouse(holderObject.GetScreenPosition(), 0.1f);
+            altDriver.KeyUp(AltKeyCode.Mouse0);
+            var finalPosition = altDriver.FindObject(By.NAME, "0-Object").GetScreenPosition();
+            Assert.That(!initialPosition.Equals(finalPosition));
+        }
+        [Test]
+        public void TestMoveLettersWithTouch()
+        {
+            var holderObject = altDriver.FindObject(By.NAME, "Holder Object (0)");
+            var dragObject = altDriver.FindObject(By.NAME, "0-Object");
+            var initialPosition = dragObject.GetScreenPosition();
+            var touch = altDriver.BeginTouch(initialPosition);
+            altDriver.MoveTouch(touch, holderObject.GetScreenPosition());
+            altDriver.EndTouch(touch);
+            var finalPosition = altDriver.FindObject(By.NAME, "0-Object").GetScreenPosition();
+            Assert.That(!initialPosition.Equals(finalPosition));
+        }
 
     }
-    [Test]
-    public void TestMoveLettersWithKeyDownUp()
-    {
-        var holderObject = altDriver.FindObject(By.NAME, "Holder Object (0)");
-        var dragObject = altDriver.FindObject(By.NAME, "0-Object");
-        var initialPosition = dragObject.GetScreenPosition();
-        altDriver.MoveMouse(initialPosition, 0.1f);
-        altDriver.KeyDown(AltKeyCode.Mouse0);
-        altDriver.MoveMouse(holderObject.GetScreenPosition(), 0.1f);
-        altDriver.KeyUp(AltKeyCode.Mouse0);
-        var finalPosition = altDriver.FindObject(By.NAME, "0-Object").GetScreenPosition();
-        Assert.That(!initialPosition.Equals(finalPosition));
-    }
-    [Test]
-    public void TestMoveLettersWithTouch()
-    {
-        var holderObject = altDriver.FindObject(By.NAME, "Holder Object (0)");
-        var dragObject = altDriver.FindObject(By.NAME, "0-Object");
-        var initialPosition = dragObject.GetScreenPosition();
-        var touch = altDriver.BeginTouch(initialPosition);
-        altDriver.MoveTouch(touch, holderObject.GetScreenPosition());
-        altDriver.EndTouch(touch);
-        var finalPosition = altDriver.FindObject(By.NAME, "0-Object").GetScreenPosition();
-        Assert.That(!initialPosition.Equals(finalPosition));
-    }
-
 }

--- a/Assets/Examples/Test/Editor/Driver/TestForNIS.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestForNIS.cs
@@ -22,351 +22,356 @@ using AltTester.AltTesterUnitySDK.Driver;
 using AltTester.AltTesterUnitySDK.Driver.Tests;
 using NUnit.Framework;
 
-public class TestForNIS
+namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
-    public AltDriver altDriver;
-    //Before any test it connects with the socket
-    string scene7 = "Assets/Examples/Scenes/Scene 7 Drag And Drop NIS.unity";
-    string scene8 = "Assets/Examples/Scenes/Scene 8 Draggable Panel NIP.unity";
-    string scene9 = "Assets/Examples/Scenes/scene 9 NIS.unity";
-    string scene10 = "Assets/Examples/Scenes/Scene 10 Sample NIS.unity";
-    string scene11 = "Assets/Examples/Scenes/Scene 7 New Input System Actions.unity";
+    [TestFixture]
+    [Parallelizable]
+    public class TestForNIS
+    {
+        public AltDriver altDriver;
+        //Before any test it connects with the socket
+        string scene7 = "Assets/Examples/Scenes/Scene 7 Drag And Drop NIS.unity";
+        string scene8 = "Assets/Examples/Scenes/Scene 8 Draggable Panel NIP.unity";
+        string scene9 = "Assets/Examples/Scenes/scene 9 NIS.unity";
+        string scene10 = "Assets/Examples/Scenes/Scene 10 Sample NIS.unity";
+        string scene11 = "Assets/Examples/Scenes/Scene 7 New Input System Actions.unity";
 
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-        altDriver = TestsHelper.GetAltDriver();
-    }
-
-    //At the end of the test closes the connection with the socket
-    [OneTimeTearDown]
-    public void TearDown()
-    {
-        altDriver.Stop();
-    }
-    [SetUp]
-    public void SetUp()
-    {
-        altDriver.ResetInput();
-    }
-    private void getSpriteName(out string imageSource, out string imageSourceDropZone, string sourceImageName, string imageSourceDropZoneName)
-    {
-        imageSource = altDriver.FindObject(By.NAME, sourceImageName).GetComponentProperty<string>("UnityEngine.UI.Image", "sprite.name", "UnityEngine.UI");
-        imageSourceDropZone = altDriver.FindObject(By.NAME, imageSourceDropZoneName).GetComponentProperty<string>("UnityEngine.UI.Image", "sprite.name", "UnityEngine.UI");
-    }
-    private void dropImageWithMultipointSwipe(string[] objectNames, float duration = 1f, bool wait = true)
-    {
-        AltVector2[] listPositions = new AltVector2[objectNames.Length];
-        for (int i = 0; i < objectNames.Length; i++)
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
         {
-            var obj = altDriver.FindObject(By.NAME, objectNames[i]);
-            listPositions[i] = obj.GetScreenPosition();
+            altDriver = TestsHelper.GetAltDriver();
         }
-        altDriver.MultipointSwipe(listPositions, duration, wait: wait);
-    }
 
-    [Test]
-    public void TestScroll()
-    {
-        altDriver.LoadScene(scene10);
-        var player = altDriver.FindObject(By.NAME, "Player");
-        Assert.False(player.GetComponentProperty<bool>("AltNIPDebugScript", "wasScrolled", "Assembly-CSharp"));
-        altDriver.Scroll(300, 0.5f, true);
-        Assert.True(player.GetComponentProperty<bool>("AltNIPDebugScript", "wasScrolled", "Assembly-CSharp"));
-    }
+        //At the end of the test closes the connection with the socket
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            altDriver.Stop();
+        }
+        [SetUp]
+        public void SetUp()
+        {
+            altDriver.ResetInput();
+        }
+        private void getSpriteName(out string imageSource, out string imageSourceDropZone, string sourceImageName, string imageSourceDropZoneName)
+        {
+            imageSource = altDriver.FindObject(By.NAME, sourceImageName).GetComponentProperty<string>("UnityEngine.UI.Image", "sprite.name", "UnityEngine.UI");
+            imageSourceDropZone = altDriver.FindObject(By.NAME, imageSourceDropZoneName).GetComponentProperty<string>("UnityEngine.UI.Image", "sprite.name", "UnityEngine.UI");
+        }
+        private void dropImageWithMultipointSwipe(string[] objectNames, float duration = 1f, bool wait = true)
+        {
+            AltVector2[] listPositions = new AltVector2[objectNames.Length];
+            for (int i = 0; i < objectNames.Length; i++)
+            {
+                var obj = altDriver.FindObject(By.NAME, objectNames[i]);
+                listPositions[i] = obj.GetScreenPosition();
+            }
+            altDriver.MultipointSwipe(listPositions, duration, wait: wait);
+        }
 
-
-    [Test]
-    public void TestTapElement()
-    {
-        altDriver.LoadScene(scene8);
-        var closeButton = altDriver.FindObject(By.PATH, "//Panel Drag Area/Panel/Close Button");
-        closeButton.Tap();
-        altDriver.WaitForObjectNotBePresent(By.PATH, "//Panel Drag Area/Panel");
-    }
-
-    [Test]
-    public void TestTapCoordinates()
-    {
-        altDriver.LoadScene(scene8);
-        var closeButton = altDriver.FindObject(By.PATH, "//Panel Drag Area/Panel/Close Button");
-        altDriver.Tap(closeButton.GetScreenPosition());
-        altDriver.WaitForObjectNotBePresent(By.PATH, "//Panel Drag Area/Panel");
-    }
-
-    [Test]
-    public void TestScrollElement()
-    {
-        altDriver.LoadScene(scene9);
-        var scrollbar = altDriver.FindObject(By.NAME, "Scrollbar Vertical");
-        var scrollbarPosition = scrollbar.GetComponentProperty<float>("UnityEngine.UI.Scrollbar", "value", "UnityEngine.UI");
-        altDriver.MoveMouse(altDriver.FindObject(By.NAME, "Scroll View").GetScreenPosition(), 0.5f);
-        altDriver.Scroll(new AltVector2(-3000, -3000), 0.5f, true);
-        var scrollbarPositionFinal = scrollbar.GetComponentProperty<float>("UnityEngine.UI.Scrollbar", "value", "UnityEngine.UI");
-        Assert.AreNotEqual(scrollbarPosition, scrollbarPositionFinal);
-
-    }
-
-    [Test]
-    public void TestClickElement()
-    {
-        altDriver.LoadScene(scene11);
-        var capsule = altDriver.FindObject(By.NAME, "Capsule");
-        capsule.Click();
-        var counter = capsule.GetComponentProperty<int>("AltExampleNewInputSystem", "jumpCounter", "Assembly-CSharp");
-        Assert.AreEqual(1, counter);
-    }
+        [Test]
+        public void TestScroll()
+        {
+            altDriver.LoadScene(scene10);
+            var player = altDriver.FindObject(By.NAME, "Player");
+            Assert.False(player.GetComponentProperty<bool>("AltNIPDebugScript", "wasScrolled", "Assembly-CSharp"));
+            altDriver.Scroll(300, 0.5f, true);
+            Assert.True(player.GetComponentProperty<bool>("AltNIPDebugScript", "wasScrolled", "Assembly-CSharp"));
+        }
 
 
-    [Test]
-    public void TestKeyDownAndKeyUp()
-    {
-        altDriver.LoadScene(scene10);
-        var player = altDriver.FindObject(By.NAME, "Player");
-        for (AltKeyCode altKeyCode = AltKeyCode.Backspace; altKeyCode <= AltKeyCode.F12; altKeyCode++) //because F13->F15 is present in KeyCode but not in Key
-            keyboardKeyDownAndUp(player, altKeyCode);
-        for (AltKeyCode altKeyCode = AltKeyCode.Numlock; altKeyCode <= AltKeyCode.Menu; altKeyCode++)
-            keyboardKeyDownAndUp(player, altKeyCode);
-        for (AltKeyCode altKeyCode = AltKeyCode.Mouse0; altKeyCode <= AltKeyCode.Mouse4; altKeyCode++)
+        [Test]
+        public void TestTapElement()
+        {
+            altDriver.LoadScene(scene8);
+            var closeButton = altDriver.FindObject(By.PATH, "//Panel Drag Area/Panel/Close Button");
+            closeButton.Tap();
+            altDriver.WaitForObjectNotBePresent(By.PATH, "//Panel Drag Area/Panel");
+        }
+
+        [Test]
+        public void TestTapCoordinates()
+        {
+            altDriver.LoadScene(scene8);
+            var closeButton = altDriver.FindObject(By.PATH, "//Panel Drag Area/Panel/Close Button");
+            altDriver.Tap(closeButton.GetScreenPosition());
+            altDriver.WaitForObjectNotBePresent(By.PATH, "//Panel Drag Area/Panel");
+        }
+
+        [Test]
+        public void TestScrollElement()
+        {
+            altDriver.LoadScene(scene9);
+            var scrollbar = altDriver.FindObject(By.NAME, "Scrollbar Vertical");
+            var scrollbarPosition = scrollbar.GetComponentProperty<float>("UnityEngine.UI.Scrollbar", "value", "UnityEngine.UI");
+            altDriver.MoveMouse(altDriver.FindObject(By.NAME, "Scroll View").GetScreenPosition(), 0.5f);
+            altDriver.Scroll(new AltVector2(-3000, -3000), 0.5f, true);
+            var scrollbarPositionFinal = scrollbar.GetComponentProperty<float>("UnityEngine.UI.Scrollbar", "value", "UnityEngine.UI");
+            Assert.AreNotEqual(scrollbarPosition, scrollbarPositionFinal);
+
+        }
+
+        [Test]
+        public void TestClickElement()
+        {
+            altDriver.LoadScene(scene11);
+            var capsule = altDriver.FindObject(By.NAME, "Capsule");
+            capsule.Click();
+            var counter = capsule.GetComponentProperty<int>("AltExampleNewInputSystem", "jumpCounter", "Assembly-CSharp");
+            Assert.AreEqual(1, counter);
+        }
+
+
+        [Test]
+        public void TestKeyDownAndKeyUp()
+        {
+            altDriver.LoadScene(scene10);
+            var player = altDriver.FindObject(By.NAME, "Player");
+            for (AltKeyCode altKeyCode = AltKeyCode.Backspace; altKeyCode <= AltKeyCode.F12; altKeyCode++) //because F13->F15 is present in KeyCode but not in Key
+                keyboardKeyDownAndUp(player, altKeyCode);
+            for (AltKeyCode altKeyCode = AltKeyCode.Numlock; altKeyCode <= AltKeyCode.Menu; altKeyCode++)
+                keyboardKeyDownAndUp(player, altKeyCode);
+            for (AltKeyCode altKeyCode = AltKeyCode.Mouse0; altKeyCode <= AltKeyCode.Mouse4; altKeyCode++)
+                if (Enum.IsDefined(typeof(AltKeyCode), altKeyCode))
+                {
+                    altDriver.KeyDown(altKeyCode);
+                    Thread.Sleep(100);
+                    altDriver.KeyUp(altKeyCode);
+                    var keyPressed = player.GetComponentProperty<string>("AltNIPDebugScript", "MousePressed", "Assembly-CSharp");
+                    var keyReleased = player.GetComponentProperty<string>("AltNIPDebugScript", "MouseReleased", "Assembly-CSharp");
+                    Assert.AreEqual(altKeyCode.ToString(), keyPressed);
+                    Assert.AreEqual(altKeyCode.ToString(), keyReleased);
+                }
+            for (AltKeyCode altKeyCode = AltKeyCode.JoystickButton0; altKeyCode <= AltKeyCode.JoystickButton19; altKeyCode++)
+                joystickKeyDownAndUp(player, altKeyCode, 1);
+            for (AltKeyCode altKeyCode = AltKeyCode.JoystickButton16; altKeyCode <= AltKeyCode.JoystickButton19; altKeyCode++) //for axis.x < 0 and axis.y < 0
+                joystickKeyDownAndUp(player, altKeyCode, -1);
+        }
+
+        private void keyboardKeyDownAndUp(AltObject player, AltKeyCode altKeyCode)
+        {
             if (Enum.IsDefined(typeof(AltKeyCode), altKeyCode))
             {
                 altDriver.KeyDown(altKeyCode);
                 Thread.Sleep(100);
                 altDriver.KeyUp(altKeyCode);
-                var keyPressed = player.GetComponentProperty<string>("AltNIPDebugScript", "MousePressed", "Assembly-CSharp");
-                var keyReleased = player.GetComponentProperty<string>("AltNIPDebugScript", "MouseReleased", "Assembly-CSharp");
-                Assert.AreEqual(altKeyCode.ToString(), keyPressed);
-                Assert.AreEqual(altKeyCode.ToString(), keyReleased);
+                var keyPressed = player.GetComponentProperty<List<int>>("AltNIPDebugScript", "KeyPressed", "Assembly-CSharp");
+                var keyReleased = player.GetComponentProperty<List<int>>("AltNIPDebugScript", "KeyReleased", "Assembly-CSharp");
+                Assert.Contains((int)altKeyCode, keyPressed);
+                Assert.Contains((int)altKeyCode, keyReleased);
             }
-        for (AltKeyCode altKeyCode = AltKeyCode.JoystickButton0; altKeyCode <= AltKeyCode.JoystickButton19; altKeyCode++)
-            joystickKeyDownAndUp(player, altKeyCode, 1);
-        for (AltKeyCode altKeyCode = AltKeyCode.JoystickButton16; altKeyCode <= AltKeyCode.JoystickButton19; altKeyCode++) //for axis.x < 0 and axis.y < 0
-            joystickKeyDownAndUp(player, altKeyCode, -1);
-    }
+        }
 
-    private void keyboardKeyDownAndUp(AltObject player, AltKeyCode altKeyCode)
-    {
-        if (Enum.IsDefined(typeof(AltKeyCode), altKeyCode))
+        private void joystickKeyDownAndUp(AltObject player, AltKeyCode altKeyCode, float power)
         {
-            altDriver.KeyDown(altKeyCode);
+            altDriver.KeyDown(altKeyCode, power);
             Thread.Sleep(100);
             altDriver.KeyUp(altKeyCode);
-            var keyPressed = player.GetComponentProperty<List<int>>("AltNIPDebugScript", "KeyPressed", "Assembly-CSharp");
-            var keyReleased = player.GetComponentProperty<List<int>>("AltNIPDebugScript", "KeyReleased", "Assembly-CSharp");
-            Assert.Contains((int)altKeyCode, keyPressed);
-            Assert.Contains((int)altKeyCode, keyReleased);
+            var keyPressed = player.GetComponentProperty<string>("AltNIPDebugScript", "JoystickPressed", "Assembly-CSharp");
+            var keyReleased = player.GetComponentProperty<string>("AltNIPDebugScript", "JoystickReleased", "Assembly-CSharp");
+            Assert.AreEqual(altKeyCode.ToString(), keyPressed);
+            Assert.AreEqual(altKeyCode.ToString(), keyReleased);
         }
-    }
 
-    private void joystickKeyDownAndUp(AltObject player, AltKeyCode altKeyCode, float power)
-    {
-        altDriver.KeyDown(altKeyCode, power);
-        Thread.Sleep(100);
-        altDriver.KeyUp(altKeyCode);
-        var keyPressed = player.GetComponentProperty<string>("AltNIPDebugScript", "JoystickPressed", "Assembly-CSharp");
-        var keyReleased = player.GetComponentProperty<string>("AltNIPDebugScript", "JoystickReleased", "Assembly-CSharp");
-        Assert.AreEqual(altKeyCode.ToString(), keyPressed);
-        Assert.AreEqual(altKeyCode.ToString(), keyReleased);
-    }
+        [Test]
+        public void TestPressKey()
+        {
+            altDriver.LoadScene(scene10);
+            var player = altDriver.FindObject(By.NAME, "Player");
+            var initialPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
+            altDriver.PressKey(AltKeyCode.A);
+            var leftPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
+            Assert.AreNotEqual(initialPos, leftPos);
+            altDriver.PressKey(AltKeyCode.D);
+            var rightPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
+            Assert.AreNotEqual(leftPos, rightPos);
+            altDriver.PressKey(AltKeyCode.W);
+            var upPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
+            Assert.AreNotEqual(rightPos, upPos);
+            altDriver.PressKey(AltKeyCode.S);
+            var downPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
+            Assert.AreNotEqual(upPos, downPos);
 
-    [Test]
-    public void TestPressKey()
-    {
-        altDriver.LoadScene(scene10);
-        var player = altDriver.FindObject(By.NAME, "Player");
-        var initialPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
-        altDriver.PressKey(AltKeyCode.A);
-        var leftPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
-        Assert.AreNotEqual(initialPos, leftPos);
-        altDriver.PressKey(AltKeyCode.D);
-        var rightPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
-        Assert.AreNotEqual(leftPos, rightPos);
-        altDriver.PressKey(AltKeyCode.W);
-        var upPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
-        Assert.AreNotEqual(rightPos, upPos);
-        altDriver.PressKey(AltKeyCode.S);
-        var downPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
-        Assert.AreNotEqual(upPos, downPos);
+        }
 
-    }
+        [Test]
+        public void TestPressKeys()
+        {
+            altDriver.LoadScene(scene10);
+            var player = altDriver.FindObject(By.NAME, "Player");
+            var initialPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
+            AltKeyCode[] keys = { AltKeyCode.W, AltKeyCode.Mouse0 };
+            altDriver.PressKeys(keys);
+            var finalPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
+            altDriver.WaitForObject(By.NAME, "SimpleProjectile(Clone)");
+            Assert.AreNotEqual(initialPos, finalPos);
+        }
 
-    [Test]
-    public void TestPressKeys()
-    {
-        altDriver.LoadScene(scene10);
-        var player = altDriver.FindObject(By.NAME, "Player");
-        var initialPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
-        AltKeyCode[] keys = { AltKeyCode.W, AltKeyCode.Mouse0 };
-        altDriver.PressKeys(keys);
-        var finalPos = player.GetComponentProperty<AltVector3>("UnityEngine.Transform", "position", "UnityEngine.CoreModule");
-        altDriver.WaitForObject(By.NAME, "SimpleProjectile(Clone)");
-        Assert.AreNotEqual(initialPos, finalPos);
-    }
+        [Test]
+        public void TestPressAllKeys()
+        {
+            altDriver.LoadScene(scene10);
 
-    [Test]
-    public void TestPressAllKeys()
-    {
-        altDriver.LoadScene(scene10);
+            var player = altDriver.FindObject(By.NAME, "Player");
+            for (AltKeyCode altKeyCode = AltKeyCode.Backspace; altKeyCode <= AltKeyCode.F12; altKeyCode++) //because F13->F15 is present in KeyCode but not in Key
+                keyboardKeyPress(player, altKeyCode);
+            for (AltKeyCode altKeyCode = AltKeyCode.Numlock; altKeyCode <= AltKeyCode.Menu; altKeyCode++)
+                keyboardKeyPress(player, altKeyCode);
+            for (AltKeyCode altKeyCode = AltKeyCode.Mouse0; altKeyCode <= AltKeyCode.Mouse4; altKeyCode++)
+                if (Enum.IsDefined(typeof(AltKeyCode), altKeyCode))
+                {
+                    altDriver.PressKey(altKeyCode);
+                    var keyPressed = player.GetComponentProperty<string>("AltNIPDebugScript", "MousePressed", "Assembly-CSharp");
+                    var keyReleased = player.GetComponentProperty<string>("AltNIPDebugScript", "MouseReleased", "Assembly-CSharp");
+                    Assert.AreEqual(altKeyCode.ToString(), keyPressed);
+                    Assert.AreEqual(altKeyCode.ToString(), keyReleased);
+                }
+            for (AltKeyCode altKeyCode = AltKeyCode.JoystickButton0; altKeyCode <= AltKeyCode.JoystickButton19; altKeyCode++)
+                joystickKeyPress(player, altKeyCode, 1);
+            for (AltKeyCode altKeyCode = AltKeyCode.JoystickButton16; altKeyCode <= AltKeyCode.JoystickButton19; altKeyCode++) //for axis.x < 0 and axis.y < 0
+                joystickKeyPress(player, altKeyCode, -1);
+        }
 
-        var player = altDriver.FindObject(By.NAME, "Player");
-        for (AltKeyCode altKeyCode = AltKeyCode.Backspace; altKeyCode <= AltKeyCode.F12; altKeyCode++) //because F13->F15 is present in KeyCode but not in Key
-            keyboardKeyPress(player, altKeyCode);
-        for (AltKeyCode altKeyCode = AltKeyCode.Numlock; altKeyCode <= AltKeyCode.Menu; altKeyCode++)
-            keyboardKeyPress(player, altKeyCode);
-        for (AltKeyCode altKeyCode = AltKeyCode.Mouse0; altKeyCode <= AltKeyCode.Mouse4; altKeyCode++)
+
+        private void keyboardKeyPress(AltObject player, AltKeyCode altKeyCode)
+        {
             if (Enum.IsDefined(typeof(AltKeyCode), altKeyCode))
             {
                 altDriver.PressKey(altKeyCode);
-                var keyPressed = player.GetComponentProperty<string>("AltNIPDebugScript", "MousePressed", "Assembly-CSharp");
-                var keyReleased = player.GetComponentProperty<string>("AltNIPDebugScript", "MouseReleased", "Assembly-CSharp");
-                Assert.AreEqual(altKeyCode.ToString(), keyPressed);
-                Assert.AreEqual(altKeyCode.ToString(), keyReleased);
+                var keyPressed = player.GetComponentProperty<List<int>>("AltNIPDebugScript", "KeyPressed", "Assembly-CSharp");
+                var keyReleased = player.GetComponentProperty<List<int>>("AltNIPDebugScript", "KeyReleased", "Assembly-CSharp");
+                Assert.Contains((int)altKeyCode, keyPressed);
+                Assert.Contains((int)altKeyCode, keyReleased);
             }
-        for (AltKeyCode altKeyCode = AltKeyCode.JoystickButton0; altKeyCode <= AltKeyCode.JoystickButton19; altKeyCode++)
-            joystickKeyPress(player, altKeyCode, 1);
-        for (AltKeyCode altKeyCode = AltKeyCode.JoystickButton16; altKeyCode <= AltKeyCode.JoystickButton19; altKeyCode++) //for axis.x < 0 and axis.y < 0
-            joystickKeyPress(player, altKeyCode, -1);
-    }
-
-
-    private void keyboardKeyPress(AltObject player, AltKeyCode altKeyCode)
-    {
-        if (Enum.IsDefined(typeof(AltKeyCode), altKeyCode))
-        {
-            altDriver.PressKey(altKeyCode);
-            var keyPressed = player.GetComponentProperty<List<int>>("AltNIPDebugScript", "KeyPressed", "Assembly-CSharp");
-            var keyReleased = player.GetComponentProperty<List<int>>("AltNIPDebugScript", "KeyReleased", "Assembly-CSharp");
-            Assert.Contains((int)altKeyCode, keyPressed);
-            Assert.Contains((int)altKeyCode, keyReleased);
         }
-    }
 
-    private void joystickKeyPress(AltObject player, AltKeyCode altKeyCode, float power)
-    {
-        altDriver.PressKey(altKeyCode, power);
-        var keyPressed = player.GetComponentProperty<string>("AltNIPDebugScript", "JoystickPressed", "Assembly-CSharp");
-        var keyReleased = player.GetComponentProperty<string>("AltNIPDebugScript", "JoystickReleased", "Assembly-CSharp");
-        Assert.AreEqual(altKeyCode.ToString(), keyPressed);
-        Assert.AreEqual(altKeyCode.ToString(), keyReleased);
-
-    }
-
-    [Test]
-    public void TestClickCoordinates()
-    {
-        altDriver.LoadScene(scene11);
-        var capsule = altDriver.FindObject(By.NAME, "Capsule");
-        altDriver.Click(capsule.GetScreenPosition());
-        altDriver.WaitForObject(By.PATH, "//ActionText[@text=Capsule was clicked!]", timeout: 1);
-    }
-
-    [Test]
-    public void TestTilt()
-    {
-        altDriver.LoadScene(scene11);
-        var cube = altDriver.FindObject(By.NAME, "Cube (1)");
-        var initialPosition = cube.GetWorldPosition();
-        altDriver.Tilt(new AltVector3(5, 0, 5f), 1f);
-        Assert.AreNotEqual(initialPosition, altDriver.FindObject(By.NAME, "Cube (1)").GetWorldPosition());
-        Assert.IsTrue(cube.GetComponentProperty<bool>("AltCubeNIS", "isMoved", "Assembly-CSharp"));
-    }
-
-    [Test]
-    public void TestSwipe()
-    {
-        altDriver.LoadScene(scene9);
-        var scrollbarPosition = altDriver.FindObject(By.NAME, "Handle").GetScreenPosition();
-        var button = altDriver.FindObject(By.PATH, "//Scroll View/Viewport/Content/Button (4)");
-        altDriver.Swipe(new AltVector2(button.x + 1, button.y + 1), new AltVector2(button.x + 1, button.y + 20), 1);
-        var scrollbarPositionFinal = altDriver.FindObject(By.NAME, "Handle").GetScreenPosition();
-        Assert.AreNotEqual(scrollbarPosition.y, scrollbarPositionFinal.y);
-    }
-
-    [Test]
-    public void TestMultipointSwipe()
-    {
-        altDriver.LoadScene(scene7);
-        string imageSource, imageSourceDropZone;
-        dropImageWithMultipointSwipe(new[] { "Drag Image1", "Drop Box1" });
-        dropImageWithMultipointSwipe(new[] { "Drag Image2", "Drop Box1", "Drop Box2" });
-
-        getSpriteName(out imageSource, out imageSourceDropZone, "Drag Image1", "Drop Image");
-        Assert.AreEqual(imageSource, imageSourceDropZone);
-
-        getSpriteName(out imageSource, out imageSourceDropZone, "Drag Image2", "Drop");
-        Assert.AreEqual(imageSource, imageSourceDropZone);
-    }
-
-    [Test]
-    public void TestBeginMoveEndTouch()
-    {
-        altDriver.LoadScene(scene8);
-        var panelToDrag = altDriver.FindObject(By.PATH, "//Panel/Drag Zone");
-        var initialPanelPos = panelToDrag.GetScreenPosition();
-        var fingerId = altDriver.BeginTouch(initialPanelPos);
-        altDriver.MoveTouch(fingerId, new AltVector2(initialPanelPos.x + 1, initialPanelPos.y + 1));
-        altDriver.MoveTouch(fingerId, new AltVector2(initialPanelPos.x + 200, initialPanelPos.y + 20));
-        altDriver.EndTouch(fingerId);
-        var finalPanelPos = altDriver.FindObject(By.PATH, "//Panel/Drag Zone").GetScreenPosition();
-        Assert.AreNotEqual(initialPanelPos, finalPanelPos);
-    }
-
-    [Test]
-    public void TestCapsuleJumps()
-    {
-        altDriver.LoadScene(scene11);
-        var capsule = altDriver.FindObject(By.NAME, "Capsule");
-        var fingerId = altDriver.BeginTouch(capsule.GetScreenPosition());
-        altDriver.EndTouch(fingerId);
-        var text = capsule.GetComponentProperty<string>("AltExampleNewInputSystem", "actionText.text", "Assembly-CSharp");
-        Assert.AreEqual("Capsule was tapped!", text);
-    }
-
-    [Ignore("Flaky. Skip until https://github.com/alttester/AltTester-Unity-SDK/issues/1130 is fixed.")]
-    [TestCase(1)]
-    [TestCase(2)]
-    [TestCase(3)]
-    public void TestCheckActionDoNotDoubleClick(int numberOfClicks)
-    {
-        altDriver.LoadScene(scene11);
-        float interval = 0.3f;
-        altDriver.SetDelayAfterCommand(0.1f);
-        var counterButton = altDriver.FindObject(By.NAME, "Canvas/Button");
-        var text = altDriver.FindObject(By.NAME, "Canvas/Button/Text");
-        counterButton.Click(numberOfClicks, interval);
-        Assert.AreEqual(numberOfClicks, int.Parse(text.GetText()));
-        counterButton.Tap(numberOfClicks, interval);
-        Assert.AreEqual(2 * numberOfClicks, int.Parse(text.GetText()));
-        altDriver.Click(counterButton.GetScreenPosition(), numberOfClicks, interval);
-        Assert.AreEqual(3 * numberOfClicks, int.Parse(text.GetText()));
-        altDriver.Tap(counterButton.GetScreenPosition(), numberOfClicks, interval);
-        Assert.AreEqual(4 * numberOfClicks, int.Parse(text.GetText()));
-        altDriver.MoveMouse(counterButton.GetScreenPosition(), interval);
-        for (int i = 0; i < numberOfClicks; i++)
+        private void joystickKeyPress(AltObject player, AltKeyCode altKeyCode, float power)
         {
-            altDriver.KeyDown(AltKeyCode.Mouse0);
-            altDriver.KeyUp(AltKeyCode.Mouse0);
-        }
-        Assert.AreEqual(5 * numberOfClicks, int.Parse(text.GetText()));
-        for (int i = 0; i < numberOfClicks; i++)
-        {
-            altDriver.HoldButton(counterButton.GetScreenPosition(), 0.1f);
-        }
-        Assert.AreEqual(6 * numberOfClicks, int.Parse(text.GetText()));
-        altDriver.SetDelayAfterCommand(0);
-    }
+            altDriver.PressKey(altKeyCode, power);
+            var keyPressed = player.GetComponentProperty<string>("AltNIPDebugScript", "JoystickPressed", "Assembly-CSharp");
+            var keyReleased = player.GetComponentProperty<string>("AltNIPDebugScript", "JoystickReleased", "Assembly-CSharp");
+            Assert.AreEqual(altKeyCode.ToString(), keyPressed);
+            Assert.AreEqual(altKeyCode.ToString(), keyReleased);
 
-    [Test]
-    public void TestOnScreenInput()
-    {
-        altDriver.LoadScene(scene10);
-        var initialPlayerPos = altDriver.FindObject(By.NAME, "Player").GetWorldPosition();
-        altDriver.FindObject(By.NAME, "Button").Tap();
-        var playerPos = altDriver.FindObject(By.NAME, "Player").GetWorldPosition();
-        Assert.AreNotEqual(initialPlayerPos, playerPos);
-        var stick = altDriver.FindObject(By.NAME, "Stick");
-        altDriver.Swipe(stick.GetScreenPosition(), stick.GetScreenPosition() * 2, 1);
-        var finalPlayerPos = altDriver.FindObject(By.NAME, "Player").GetWorldPosition();
-        Assert.AreNotEqual(playerPos, finalPlayerPos);
+        }
+
+        [Test]
+        public void TestClickCoordinates()
+        {
+            altDriver.LoadScene(scene11);
+            var capsule = altDriver.FindObject(By.NAME, "Capsule");
+            altDriver.Click(capsule.GetScreenPosition());
+            altDriver.WaitForObject(By.PATH, "//ActionText[@text=Capsule was clicked!]", timeout: 1);
+        }
+
+        [Test]
+        public void TestTilt()
+        {
+            altDriver.LoadScene(scene11);
+            var cube = altDriver.FindObject(By.NAME, "Cube (1)");
+            var initialPosition = cube.GetWorldPosition();
+            altDriver.Tilt(new AltVector3(5, 0, 5f), 1f);
+            Assert.AreNotEqual(initialPosition, altDriver.FindObject(By.NAME, "Cube (1)").GetWorldPosition());
+            Assert.IsTrue(cube.GetComponentProperty<bool>("AltCubeNIS", "isMoved", "Assembly-CSharp"));
+        }
+
+        [Test]
+        public void TestSwipe()
+        {
+            altDriver.LoadScene(scene9);
+            var scrollbarPosition = altDriver.FindObject(By.NAME, "Handle").GetScreenPosition();
+            var button = altDriver.FindObject(By.PATH, "//Scroll View/Viewport/Content/Button (4)");
+            altDriver.Swipe(new AltVector2(button.x + 1, button.y + 1), new AltVector2(button.x + 1, button.y + 20), 1);
+            var scrollbarPositionFinal = altDriver.FindObject(By.NAME, "Handle").GetScreenPosition();
+            Assert.AreNotEqual(scrollbarPosition.y, scrollbarPositionFinal.y);
+        }
+
+        [Test]
+        public void TestMultipointSwipe()
+        {
+            altDriver.LoadScene(scene7);
+            string imageSource, imageSourceDropZone;
+            dropImageWithMultipointSwipe(new[] { "Drag Image1", "Drop Box1" });
+            dropImageWithMultipointSwipe(new[] { "Drag Image2", "Drop Box1", "Drop Box2" });
+
+            getSpriteName(out imageSource, out imageSourceDropZone, "Drag Image1", "Drop Image");
+            Assert.AreEqual(imageSource, imageSourceDropZone);
+
+            getSpriteName(out imageSource, out imageSourceDropZone, "Drag Image2", "Drop");
+            Assert.AreEqual(imageSource, imageSourceDropZone);
+        }
+
+        [Test]
+        public void TestBeginMoveEndTouch()
+        {
+            altDriver.LoadScene(scene8);
+            var panelToDrag = altDriver.FindObject(By.PATH, "//Panel/Drag Zone");
+            var initialPanelPos = panelToDrag.GetScreenPosition();
+            var fingerId = altDriver.BeginTouch(initialPanelPos);
+            altDriver.MoveTouch(fingerId, new AltVector2(initialPanelPos.x + 1, initialPanelPos.y + 1));
+            altDriver.MoveTouch(fingerId, new AltVector2(initialPanelPos.x + 200, initialPanelPos.y + 20));
+            altDriver.EndTouch(fingerId);
+            var finalPanelPos = altDriver.FindObject(By.PATH, "//Panel/Drag Zone").GetScreenPosition();
+            Assert.AreNotEqual(initialPanelPos, finalPanelPos);
+        }
+
+        [Test]
+        public void TestCapsuleJumps()
+        {
+            altDriver.LoadScene(scene11);
+            var capsule = altDriver.FindObject(By.NAME, "Capsule");
+            var fingerId = altDriver.BeginTouch(capsule.GetScreenPosition());
+            altDriver.EndTouch(fingerId);
+            var text = capsule.GetComponentProperty<string>("AltExampleNewInputSystem", "actionText.text", "Assembly-CSharp");
+            Assert.AreEqual("Capsule was tapped!", text);
+        }
+
+        [Ignore("Flaky. Skip until https://github.com/alttester/AltTester-Unity-SDK/issues/1130 is fixed.")]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        public void TestCheckActionDoNotDoubleClick(int numberOfClicks)
+        {
+            altDriver.LoadScene(scene11);
+            float interval = 0.3f;
+            altDriver.SetDelayAfterCommand(0.1f);
+            var counterButton = altDriver.FindObject(By.NAME, "Canvas/Button");
+            var text = altDriver.FindObject(By.NAME, "Canvas/Button/Text");
+            counterButton.Click(numberOfClicks, interval);
+            Assert.AreEqual(numberOfClicks, int.Parse(text.GetText()));
+            counterButton.Tap(numberOfClicks, interval);
+            Assert.AreEqual(2 * numberOfClicks, int.Parse(text.GetText()));
+            altDriver.Click(counterButton.GetScreenPosition(), numberOfClicks, interval);
+            Assert.AreEqual(3 * numberOfClicks, int.Parse(text.GetText()));
+            altDriver.Tap(counterButton.GetScreenPosition(), numberOfClicks, interval);
+            Assert.AreEqual(4 * numberOfClicks, int.Parse(text.GetText()));
+            altDriver.MoveMouse(counterButton.GetScreenPosition(), interval);
+            for (int i = 0; i < numberOfClicks; i++)
+            {
+                altDriver.KeyDown(AltKeyCode.Mouse0);
+                altDriver.KeyUp(AltKeyCode.Mouse0);
+            }
+            Assert.AreEqual(5 * numberOfClicks, int.Parse(text.GetText()));
+            for (int i = 0; i < numberOfClicks; i++)
+            {
+                altDriver.HoldButton(counterButton.GetScreenPosition(), 0.1f);
+            }
+            Assert.AreEqual(6 * numberOfClicks, int.Parse(text.GetText()));
+            altDriver.SetDelayAfterCommand(0);
+        }
+
+        [Test]
+        public void TestOnScreenInput()
+        {
+            altDriver.LoadScene(scene10);
+            var initialPlayerPos = altDriver.FindObject(By.NAME, "Player").GetWorldPosition();
+            altDriver.FindObject(By.NAME, "Button").Tap();
+            var playerPos = altDriver.FindObject(By.NAME, "Player").GetWorldPosition();
+            Assert.AreNotEqual(initialPlayerPos, playerPos);
+            var stick = altDriver.FindObject(By.NAME, "Stick");
+            altDriver.Swipe(stick.GetScreenPosition(), stick.GetScreenPosition() * 2, 1);
+            var finalPlayerPos = altDriver.FindObject(By.NAME, "Player").GetWorldPosition();
+            Assert.AreNotEqual(playerPos, finalPlayerPos);
+        }
     }
 }

--- a/Assets/Examples/Test/Editor/Driver/TestForScene12.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestForScene12.cs
@@ -1,80 +1,85 @@
 using AltTester.AltTesterUnitySDK.Driver;
 using NUnit.Framework;
 
-public class TestForScene12 : TestBase
-{   //Important! If your test file is inside a folder that contains an .asmdef file, please make sure that the assembly definition references NUnit.
+namespace AltTester.AltTesterUnitySDK.Driver.Tests
+{
+    [TestFixture]
+    [Parallelizable]
+    public class TestForScene12 : TestBase
+    {   //Important! If your test file is inside a folder that contains an .asmdef file, please make sure that the assembly definition references NUnit.
 
-    public TestForScene12()
-    {
-        sceneName = "Sceme 12 2D Objects";
-    }
+        public TestForScene12()
+        {
+            sceneName = "Sceme 12 2D Objects";
+        }
 
-    [TestCase("Square")]
-    [TestCase("Circle")]
-    [TestCase("Triangle")]
-    public void TestClickOnObjets(string name)
-    {
-        var altObject = altDriver.FindObject(By.NAME, name);
-        altObject.Click();
-        Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
-    }
-    [TestCase("Square")]
-    [TestCase("Circle")]
-    [TestCase("Triangle")]
-    public void TestTapOnObjets(string name)
-    {
-        var altObject = altDriver.FindObject(By.NAME, name);
-        altObject.Tap();
-        Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
-    }
-    [TestCase("Square")]
-    [TestCase("Circle")]
-    [TestCase("Triangle")]
-    public void TestTapOnCoordinates(string name)
-    {
-        var altObject = altDriver.FindObject(By.NAME, name);
-        altDriver.Tap(altObject.GetScreenPosition());
-        Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
-    }
+        [TestCase("Square")]
+        [TestCase("Circle")]
+        [TestCase("Triangle")]
+        public void TestClickOnObjets(string name)
+        {
+            var altObject = altDriver.FindObject(By.NAME, name);
+            altObject.Click();
+            Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
+        }
+        [TestCase("Square")]
+        [TestCase("Circle")]
+        [TestCase("Triangle")]
+        public void TestTapOnObjets(string name)
+        {
+            var altObject = altDriver.FindObject(By.NAME, name);
+            altObject.Tap();
+            Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
+        }
+        [TestCase("Square")]
+        [TestCase("Circle")]
+        [TestCase("Triangle")]
+        public void TestTapOnCoordinates(string name)
+        {
+            var altObject = altDriver.FindObject(By.NAME, name);
+            altDriver.Tap(altObject.GetScreenPosition());
+            Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
+        }
 
-    [TestCase("Square")]
-    [TestCase("Circle")]
-    [TestCase("Triangle")]
-    public void TestClickOnCoordinates(string name)
-    {
-        var altObject = altDriver.FindObject(By.NAME, name);
-        altDriver.Click(altObject.GetScreenPosition());
-        Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
-    }
+        [TestCase("Square")]
+        [TestCase("Circle")]
+        [TestCase("Triangle")]
+        public void TestClickOnCoordinates(string name)
+        {
+            var altObject = altDriver.FindObject(By.NAME, name);
+            altDriver.Click(altObject.GetScreenPosition());
+            Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
+        }
 
-    [TestCase("Square")]
-    [TestCase("Circle")]
-    [TestCase("Triangle")]
-    public void TestSwipeOnCoordinates(string name)
-    {
-        var altObject = altDriver.FindObject(By.NAME, name);
-        altDriver.HoldButton(altObject.GetScreenPosition(), 0.3f);
-        Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
-    }
-    [TestCase("Square")]
-    [TestCase("Circle")]
-    [TestCase("Triangle")]
-    public void TestTouchOnCoordinates(string name)
-    {
-        var altObject = altDriver.FindObject(By.NAME, name);
-        var id = altDriver.BeginTouch(altObject.GetScreenPosition());
-        altDriver.EndTouch(id);
-        Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
-    }
-    [Test]
-    public void TestDragObjet()
-    {
-        var altObject = altDriver.FindObject(By.NAME, "Hexagon Flat-Top");
-        var currentPosition = altObject.GetScreenPosition();
-        altDriver.Swipe(currentPosition, currentPosition * 1.1f);
-        altObject = altDriver.FindObject(By.NAME, "Hexagon Flat-Top");
-        Assert.That(currentPosition.x < altObject.GetScreenPosition().x, $"Expected x to be smaller: {currentPosition.x} but was {altObject.GetScreenPosition().x}");
-        Assert.That(currentPosition.y < altObject.GetScreenPosition().y, $"Expected y to be smaller: {currentPosition.y} but was {altObject.GetScreenPosition().y}");
-    }
+        [TestCase("Square")]
+        [TestCase("Circle")]
+        [TestCase("Triangle")]
+        public void TestSwipeOnCoordinates(string name)
+        {
+            var altObject = altDriver.FindObject(By.NAME, name);
+            altDriver.HoldButton(altObject.GetScreenPosition(), 0.3f);
+            Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
+        }
+        [TestCase("Square")]
+        [TestCase("Circle")]
+        [TestCase("Triangle")]
+        public void TestTouchOnCoordinates(string name)
+        {
+            var altObject = altDriver.FindObject(By.NAME, name);
+            var id = altDriver.BeginTouch(altObject.GetScreenPosition());
+            altDriver.EndTouch(id);
+            Assert.That($"Clicked on {name}".Equals(altDriver.FindObject(By.NAME, "Text").GetText()));
+        }
+        [Test]
+        public void TestDragObjet()
+        {
+            var altObject = altDriver.FindObject(By.NAME, "Hexagon Flat-Top");
+            var currentPosition = altObject.GetScreenPosition();
+            altDriver.Swipe(currentPosition, currentPosition * 1.1f);
+            altObject = altDriver.FindObject(By.NAME, "Hexagon Flat-Top");
+            Assert.That(currentPosition.x < altObject.GetScreenPosition().x, $"Expected x to be smaller: {currentPosition.x} but was {altObject.GetScreenPosition().x}");
+            Assert.That(currentPosition.y < altObject.GetScreenPosition().y, $"Expected y to be smaller: {currentPosition.y} but was {altObject.GetScreenPosition().y}");
+        }
 
+    }
 }

--- a/Assets/Examples/Test/Editor/Driver/TestForScene3DragAndDrop.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestForScene3DragAndDrop.cs
@@ -23,6 +23,8 @@ using NUnit.Framework;
 
 namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
+    [TestFixture]
+    [Parallelizable]
     [Timeout(10000)]
     public class TestForScene3DragAndDrop : TestBase
     {

--- a/Assets/Examples/Test/Editor/Driver/TestForScene4NoCameras.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestForScene4NoCameras.cs
@@ -21,6 +21,8 @@ using NUnit.Framework;
 
 namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
+    [TestFixture]
+    [Parallelizable]
     public class TestForScene4NoCameras : TestBase
     {
         public TestForScene4NoCameras()

--- a/Assets/Examples/Test/Editor/Driver/TestForScene5KeyboardAndMouseInput.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestForScene5KeyboardAndMouseInput.cs
@@ -24,6 +24,8 @@ using NUnit.Framework;
 
 namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
+    [TestFixture]
+    [Parallelizable]
     public class TestForScene5KeyboardAndMouseInput : TestBase
     {
 #pragma warning disable CS0618

--- a/Assets/Examples/Test/Editor/Driver/TestForscene2DraggablePanel.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestForscene2DraggablePanel.cs
@@ -23,6 +23,8 @@ using NUnit.Framework;
 
 namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
+    [TestFixture]
+    [Parallelizable]
     [Timeout(10000)]
     public class TestForScene2DraggablePanel : TestBase
     {

--- a/Assets/Examples/Test/Editor/Driver/TestInputActions.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestInputActions.cs
@@ -22,6 +22,8 @@ using NUnit.Framework;
 
 namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
+    [TestFixture]
+    [Parallelizable]
     public class TestInputActions : TestBase
     {
         public TestInputActions()

--- a/Assets/Examples/Test/Editor/Driver/TestNotification.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestNotification.cs
@@ -24,82 +24,88 @@ using AltTester.AltTesterUnitySDK.Driver.Notifications;
 using AltTester.AltTesterUnitySDK.Driver.Tests;
 using NUnit.Framework;
 
-public class TestNotification
+namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
-    private AltDriver altDriver;
-
-    [OneTimeSetUp]
-    public void SetUp()
+    [TestFixture]
+    [Parallelizable]
+    public class TestNotification
     {
-        altDriver = TestsHelper.GetAltDriver();
+        private AltDriver altDriver;
 
-        INotificationCallbacks notificationCallbacks = new MockNotificationCallBacks();
-
-        altDriver.AddNotificationListener<AltLoadSceneNotificationResultParams>(NotificationType.LOADSCENE, notificationCallbacks.SceneLoadedCallback, true);
-        altDriver.AddNotificationListener<String>(NotificationType.UNLOADSCENE, notificationCallbacks.SceneUnloadedCallback, true);
-        altDriver.AddNotificationListener<AltLogNotificationResultParams>(NotificationType.LOG, notificationCallbacks.LogCallback, true);
-        altDriver.AddNotificationListener<bool>(NotificationType.APPLICATION_PAUSED, notificationCallbacks.ApplicationPausedCallback, true);
-        DriverLogManager.SetMinLogLevel(AltLogger.Console, AltLogLevel.Info);
-        DriverLogManager.SetMinLogLevel(AltLogger.Unity, AltLogLevel.Info);
-    }
-
-    [OneTimeTearDown]
-    public void TearDown()
-    {
-        altDriver.RemoveNotificationListener(NotificationType.LOADSCENE);
-        altDriver.RemoveNotificationListener(NotificationType.UNLOADSCENE);
-        altDriver.RemoveNotificationListener(NotificationType.LOG);
-        altDriver.RemoveNotificationListener(NotificationType.APPLICATION_PAUSED);
-        altDriver.Stop();
-    }
-
-    [SetUp]
-    public void LoadLevel()
-    {
-        altDriver.ResetInput();
-        altDriver.LoadScene("Scene 1 AltDriverTestScene", true);
-    }
-
-    [Test]
-    public void TestLoadSceneNotification()
-    {
-        waitForNotificationToBeSent(MockNotificationCallBacks.LastSceneLoaded, "Scene 1 AltDriverTestScene", 10);
-        Assert.AreEqual("Scene 1 AltDriverTestScene", MockNotificationCallBacks.LastSceneLoaded);
-    }
-
-    private void waitForNotificationToBeSent(string lastSceneLoaded, string expectedValue, float timeout)
-    {
-        while (!lastSceneLoaded.Equals(expectedValue))
+        [OneTimeSetUp]
+        public void SetUp()
         {
-            Thread.Sleep(200);
-            timeout -= 0.2f;
-            if (timeout <= 0)
-                throw new TimeoutException("Notification variable not set to the desired value in time");
+
+            altDriver = TestsHelper.GetAltDriver();
+
+            INotificationCallbacks notificationCallbacks = new MockNotificationCallBacks();
+
+            altDriver.AddNotificationListener<AltLoadSceneNotificationResultParams>(NotificationType.LOADSCENE, notificationCallbacks.SceneLoadedCallback, true);
+            altDriver.AddNotificationListener<String>(NotificationType.UNLOADSCENE, notificationCallbacks.SceneUnloadedCallback, true);
+            altDriver.AddNotificationListener<AltLogNotificationResultParams>(NotificationType.LOG, notificationCallbacks.LogCallback, true);
+            altDriver.AddNotificationListener<bool>(NotificationType.APPLICATION_PAUSED, notificationCallbacks.ApplicationPausedCallback, true);
+            DriverLogManager.SetMinLogLevel(AltLogger.Console, AltLogLevel.Info);
+            DriverLogManager.SetMinLogLevel(AltLogger.Unity, AltLogLevel.Info);
         }
-    }
 
-    [Test]
-    public void TestUnloadSceneNotification()
-    {
-        altDriver.LoadScene("Scene 2 Draggable Panel", false);
-        altDriver.UnloadScene("Scene 2 Draggable Panel");
-        waitForNotificationToBeSent(MockNotificationCallBacks.LastSceneUnloaded, "Scene 2 Draggable Panel", 10);
-        Assert.AreEqual("Scene 2 Draggable Panel", MockNotificationCallBacks.LastSceneUnloaded);
-    }
+        [OneTimeTearDown]
+        public void TearDown()
+        {
+            altDriver.RemoveNotificationListener(NotificationType.LOADSCENE);
+            altDriver.RemoveNotificationListener(NotificationType.UNLOADSCENE);
+            altDriver.RemoveNotificationListener(NotificationType.LOG);
+            altDriver.RemoveNotificationListener(NotificationType.APPLICATION_PAUSED);
+            altDriver.Stop();
+        }
 
-    [Test]
-    public void TestLogNotification()
-    {
-        StringAssert.Contains("\"commandName\":\"loadScene", MockNotificationCallBacks.LogMessage);
-        Assert.AreEqual(AltLogLevel.Debug, MockNotificationCallBacks.LogLevel);
-    }
+        [SetUp]
+        public void LoadLevel()
+        {
+            altDriver.ResetInput();
+            altDriver.LoadScene("Scene 1 AltDriverTestScene", true);
+        }
 
-    [Test]
-    [Ignore("Testing")]
-    public void TestApplicationPaused()
-    {
-        var altElement = altDriver.FindObject(By.NAME, "AltTesterPrefab");
-        altElement.CallComponentMethod<string>("AltTester.AltTesterUnitySDK.AltRunner", "OnApplicationPause", "Assembly-CSharp", new object[] { true }, new string[] { "System.Boolean" });
-        Assert.IsTrue(MockNotificationCallBacks.ApplicationPaused);
+        [Test]
+        public void TestLoadSceneNotification()
+        {
+            waitForNotificationToBeSent(MockNotificationCallBacks.LastSceneLoaded, "Scene 1 AltDriverTestScene", 10);
+            Assert.AreEqual("Scene 1 AltDriverTestScene", MockNotificationCallBacks.LastSceneLoaded);
+        }
+
+        private void waitForNotificationToBeSent(string lastSceneLoaded, string expectedValue, float timeout)
+        {
+            while (!lastSceneLoaded.Equals(expectedValue))
+            {
+                Thread.Sleep(200);
+                timeout -= 0.2f;
+                if (timeout <= 0)
+                    throw new TimeoutException("Notification variable not set to the desired value in time");
+            }
+        }
+
+        [Test]
+        public void TestUnloadSceneNotification()
+        {
+            altDriver.LoadScene("Scene 2 Draggable Panel", false);
+            altDriver.UnloadScene("Scene 2 Draggable Panel");
+            waitForNotificationToBeSent(MockNotificationCallBacks.LastSceneUnloaded, "Scene 2 Draggable Panel", 10);
+            Assert.AreEqual("Scene 2 Draggable Panel", MockNotificationCallBacks.LastSceneUnloaded);
+        }
+
+        [Test]
+        public void TestLogNotification()
+        {
+            StringAssert.Contains("\"commandName\":\"loadScene", MockNotificationCallBacks.LogMessage);
+            Assert.AreEqual(AltLogLevel.Debug, MockNotificationCallBacks.LogLevel);
+        }
+
+        [Test]
+        [Ignore("Testing")]
+        public void TestApplicationPaused()
+        {
+            var altElement = altDriver.FindObject(By.NAME, "AltTesterPrefab");
+            altElement.CallComponentMethod<string>("AltTester.AltTesterUnitySDK.AltRunner", "OnApplicationPause", "Assembly-CSharp", new object[] { true }, new string[] { "System.Boolean" });
+            Assert.IsTrue(MockNotificationCallBacks.ApplicationPaused);
+        }
     }
 }

--- a/Assets/Examples/Test/Editor/Driver/TestReversePortForwarding.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestReversePortForwarding.cs
@@ -18,6 +18,8 @@
 using AltTester.AltTesterUnitySDK.Driver;
 using NUnit.Framework;
 
+[TestFixture]
+[Parallelizable]
 [Ignore("No Android pipeline is set up yet")]
 public class TestReversePortForwarding
 {

--- a/Assets/Examples/Test/Editor/Driver/Testforscene1TestSample.cs
+++ b/Assets/Examples/Test/Editor/Driver/Testforscene1TestSample.cs
@@ -24,6 +24,8 @@ using NUnit.Framework;
 
 namespace AltTester.AltTesterUnitySDK.Driver.Tests
 {
+    [TestFixture]
+    [Parallelizable]
     [Timeout(30000)]
     public class TestForScene1TestSample : TestBase
     {


### PR DESCRIPTION
This PR implements the code that allows parallel test runs from a single terminal.

Changes:
- Added [TestFixture] and [Parallelizable] tags to test classes
- Added a new file `AssemblyInfo.cs` where the number of devices is set
- Added a lock to altDriver instantiation, so that the drivers for each device are not created at the same time.
- Added the namespace `AltTester.AltTesterUnitySDK.Driver.Tests` to all classes from the `Driver` folder

Tested:
- 1 Windows Standalone & 2 Android devices on **Windows**
- 1 Windows Standalone(connected through IP) & 2 iOS devices on **MacOS**