### PR TITLE
Add release action for Robotframework library

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 jobs:
-  publish-pip-package:
+  publish-python-pip-package:
     runs-on: [self-hosted, macOS]
 
     steps:
@@ -23,6 +23,26 @@ jobs:
       - name: Upload to PyPi
         run: |
           cd "Bindings~/python"
+          python3 setup.py sdist bdist_wheel
+          python3 -m twine upload dist/*
+
+  publish-robot-pip-package:
+    runs-on: [self-hosted, macOS]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          pip install -r "Bindings~/robot/requirements.txt"
+          pip install -r "Bindings~/robot/requirements-dev.txt"
+
+      - name: Upload to PyPi
+        run: |
+          cd "Bindings~/robot"
           python3 setup.py sdist bdist_wheel
           python3 -m twine upload dist/*
 

--- a/Bindings~/robot/requirements-dev.txt
+++ b/Bindings~/robot/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Deploy
+setuptools>=38.6.0
+wheel>=0.31.0
+twine>=1.11.0

--- a/Bindings~/robot/requirements.txt
+++ b/Bindings~/robot/requirements.txt
@@ -1,2 +1,2 @@
-AltTester-Driver~=2.0.2
+AltTester-Driver~=2.1.0
 robotframework~=3.0

--- a/Bindings~/robot/requirements.txt
+++ b/Bindings~/robot/requirements.txt
@@ -1,2 +1,2 @@
-AltTester-Driver~=2.1.0
+AltTester-Driver
 robotframework~=3.0


### PR DESCRIPTION
The first version has been published here with the same steps as in the github workflow:
https://pypi.org/project/alttester-robotframework-library/0.0.1/ 