### PR TITLE
Confirm uninstall for AltTester Driver python in pipeline

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -290,7 +290,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
-          pip uninstall AltTester-Driver
+          pip uninstall -y AltTester-Driver
           pip install -r "Bindings~/python/requirements.txt"
           pip install -r "Bindings~/python/requirements-dev.txt"
           pip install -e "Bindings~/python" --root "Bindings~/python"
@@ -476,7 +476,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
-          pip uninstall AltTester-Driver
+          pip uninstall -y AltTester-Driver
           pip install -r "Bindings~/python/requirements.txt"
           pip install -r "Bindings~/python/requirements-dev.txt"
           pip install -e "Bindings~/python" --root "Bindings~/python"

--- a/.github/workflows/runs-at-night.yml
+++ b/.github/workflows/runs-at-night.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
-          pip uninstall AltTester-Driver
+          pip uninstall -y AltTester-Driver
           pip install -r "Bindings~/python/requirements.txt"
           pip install -r "Bindings~/python/requirements-dev.txt"
           pip install -e "Bindings~/python" --root "Bindings~/python"
@@ -333,7 +333,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
-          pip uninstall AltTester-Driver
+          pip uninstall -y AltTester-Driver
           pip install -r "Bindings~/python/requirements.txt"
           pip install -r "Bindings~/python/requirements-dev.txt"
           pip install -e "Bindings~/python" --root "Bindings~/python"
@@ -415,7 +415,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip setuptools wheel
-          pip uninstall AltTester-Driver
+          pip uninstall -y AltTester-Driver
           pip install -r "Bindings~/python/requirements.txt"
           pip install -r "Bindings~/python/requirements-dev.txt"
           pip install -e "Bindings~/python" --root "Bindings~/python"


### PR DESCRIPTION
The pipelines fail when the AltTester Driver python client is installed and needs to be uninstalled. A -y flag forces the uninstall to go through without separate confirmation. 