### PR TITLE
[Documentation] Inconsistent title - commands for PointerDown/Up/Enter/Exit commands

### DIFF
--- a/Assets/AltTester/Runtime/AltDriver/Common/AltObject.cs
+++ b/Assets/AltTester/Runtime/AltDriver/Common/AltObject.cs
@@ -166,28 +166,52 @@ namespace AltTester.AltTesterUnitySDK.Driver
             return altObject;
         }
 
+        [Obsolete("PointerUpFromObject is deprecated, please use PointerUp instead.")]
         public AltObject PointerUpFromObject()
+        {
+            return PointerUp();
+        }
+
+        public AltObject PointerUp()
         {
             var altObject = new AltPointerUpFromObject(CommHandler, this).Execute();
             CommHandler.SleepFor(CommHandler.GetDelayAfterCommand());
             return altObject;
         }
 
+        [Obsolete("PointerDownFromObject is deprecated, please use PointerDown instead.")]
         public AltObject PointerDownFromObject()
+        {
+            return PointerDown();
+        }
+
+        public AltObject PointerDown()
         {
             var altObject = new AltPointerDownFromObject(CommHandler, this).Execute();
             CommHandler.SleepFor(CommHandler.GetDelayAfterCommand());
             return altObject;
         }
 
+        [Obsolete("PointerEnterObject is deprecated, please use PointerEnter instead.")]
         public AltObject PointerEnterObject()
+        {
+            return PointerEnter();
+        }
+
+        public AltObject PointerEnter()
         {
             var altObject = new AltPointerEnterObject(CommHandler, this).Execute();
             CommHandler.SleepFor(CommHandler.GetDelayAfterCommand());
             return altObject;
         }
 
+        [Obsolete("PointerExitObject is deprecated, please use PointerExit instead.")]
         public AltObject PointerExitObject()
+        {
+            return PointerExit();
+        }
+        
+        public AltObject PointerExit()
         {
             var altObject = new AltPointerExitObject(CommHandler, this).Execute();
             CommHandler.SleepFor(CommHandler.GetDelayAfterCommand());

--- a/Assets/Examples/Test/Editor/Driver/TestForScene3DragAndDrop.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestForScene3DragAndDrop.cs
@@ -111,10 +111,10 @@ namespace AltTester.AltTesterUnitySDK.Driver.Tests
         {
             var altElement = altDriver.FindObject(By.NAME, "Drop Image");
             var color1 = altElement.GetComponentProperty<dynamic>("AltExampleScriptDropMe", "highlightColor", "Assembly-CSharp");
-            altDriver.FindObject(By.NAME, "Drop Image").PointerEnterObject();
+            altDriver.FindObject(By.NAME, "Drop Image").PointerEnter();
             var color2 = altElement.GetComponentProperty<dynamic>("AltExampleScriptDropMe", "highlightColor", "Assembly-CSharp");
             Assert.AreNotEqual(color1, color2);
-            altDriver.FindObject(By.NAME, "Drop Image").PointerExitObject();
+            altDriver.FindObject(By.NAME, "Drop Image").PointerExit();
             var color3 = altElement.GetComponentProperty<dynamic>("AltExampleScriptDropMe", "highlightColor", "Assembly-CSharp");
             Assert.AreNotEqual(color3, color2);
             Assert.AreEqual(color1, color3);

--- a/Assets/Examples/Test/Editor/Driver/TestForscene2DraggablePanel.cs
+++ b/Assets/Examples/Test/Editor/Driver/TestForscene2DraggablePanel.cs
@@ -155,24 +155,24 @@ namespace AltTester.AltTesterUnitySDK.Driver.Tests
 
 
         [Test]
-        public void TestPointerDownFromObject()
+        public void TestPointerDown()
         {
             var panel = altDriver.FindObject(By.NAME, "Panel");
             var color1 = panel.GetComponentProperty<AltColor>("AltExampleScriptPanel", "normalColor", "Assembly-CSharp");
-            panel.PointerDownFromObject();
+            panel.PointerDown();
             Thread.Sleep(1000);
             var color2 = panel.GetComponentProperty<AltColor>("AltExampleScriptPanel", "highlightColor", "Assembly-CSharp");
             Assert.AreNotEqual(color1, color2);
         }
 
         [Test]
-        public void TestPointerUpFromObject()
+        public void TestPointerUp()
         {
             var panel = altDriver.FindObject(By.NAME, "Panel");
             var color1 = panel.GetComponentProperty<AltColor>("AltExampleScriptPanel", "normalColor", "Assembly-CSharp");
-            panel.PointerDownFromObject();
+            panel.PointerDown();
             Thread.Sleep(1000);
-            panel.PointerUpFromObject();
+            panel.PointerUp();
             var color2 = panel.GetComponentProperty<AltColor>("AltExampleScriptPanel", "highlightColor", "Assembly-CSharp");
             Assert.AreEqual(color1, color2);
         }

--- a/Docs/source/pages/commands.md
+++ b/Docs/source/pages/commands.md
@@ -4285,7 +4285,7 @@ None
         {
             var panel = altDriver.FindObject(By.NAME, "Panel");
             var color1 = panel.GetComponentProperty("PanelScript", "normalColor", "Assembly-CSharp");
-            panel.PointerDownFromObject();
+            panel.PointerDown();
             Thread.Sleep(1000);
             var color2 = panel.GetComponentProperty("PanelScript", "highlightColor", "Assembly-CSharp");
             Assert.AreNotEqual(color1, color2);
@@ -4298,7 +4298,7 @@ None
         {
             AltObject panel = altDriver.findObject(AltDriver.By.NAME, "Panel");
             String color1 = panel.getComponentProperty(new AltGetComponentPropertyParams.Builder("PanelScript", "normalColor", "Assembly-CSharp").build(), String.class);
-            panel.pointerDownFromObject();
+            panel.pointerDown();
             Thread.sleep(1000);
             String color2 = panel.getComponentProperty(new AltGetComponentPropertyParams.Builder( "PanelScript", "highlightColor", "Assembly-CSharp").build(), String.class);
             assertTrue(color1 != color2);
@@ -4311,7 +4311,7 @@ None
             time.sleep(1)
             p_panel = self.altDriver.find_object(By.NAME, 'Panel')
             color1 = p_panel.get_component_property('PanelScript', 'normalColor', 'Assembly-CSharp')
-            p_panel.pointer_down_from_object()
+            p_panel.pointer_down()
             time.sleep(1)
             color2 = p_panel.get_component_property('PanelScript', 'highlightColor', 'Assembly-CSharp')
             self.assertNotEquals(color1, color2)
@@ -4351,9 +4351,9 @@ None
         {
             var panel = altDriver.FindObject(By.NAME, "Panel");
             var color1 = panel.GetComponentProperty("PanelScript", "normalColor", "Assembly-CSharp");
-            panel.PointerDownFromObject();
+            panel.PointerDown();
             Thread.Sleep(1000);
-            panel.PointerUpFromObject();
+            panel.PointerUp();
             var color2 = panel.GetComponentProperty("PanelScript", "highlightColor", "Assembly-CSharp");
             Assert.AreEqual(color1, color2);
         }
@@ -4366,9 +4366,9 @@ None
             AltObject panel = altDriver.findObject(AltDriver.By.NAME, "Panel");
             String color1 = panel.getComponentProperty(new AltGetComponentPropertyParams.Builder("PanelScript", "normalColor", "Assembly-CSharp").build(), String.class);
 
-            panel.pointerDownFromObject();
+            panel.pointerDown();
             Thread.sleep(1000);
-            panel.pointerUpFromObject();
+            panel.pointerUp();
             String color2 = panel.getComponentProperty(new AltGetComponentPropertyParams.Builder("PanelScript", "highlightColor", "Assembly-CSharp").build(), String.class);
 
             assertEquals(color1, color2);
@@ -4381,9 +4381,9 @@ None
             time.sleep(1)
             p_panel = self.altDriver.find_object(By.NAME, 'Panel')
             color1 = p_panel.get_component_property('PanelScript', 'normalColor', 'Assembly-CSharp')
-            p_panel.pointer_down_from_object()
+            p_panel.pointer_down()
             time.sleep(1)
-            p_panel.pointer_up_from_object()
+            p_panel.pointer_up()
             color2 = p_panel.get_component_property('PanelScript', 'highlightColor', 'Assembly-CSharp')
             self.assertEquals(color1, color2)
 
@@ -4423,10 +4423,10 @@ None
         {
             var altObject = altDriver.FindObject(By.NAME,"Drop Image");
             var color1 = altObject.GetComponentProperty("DropMe", "highlightColor", "Assembly-CSharp");
-            altDriver.FindObject(By.NAME,"Drop Image").PointerEnterObject();
+            altDriver.FindObject(By.NAME,"Drop Image").PointerEnter();
             var color2 = altObject.GetComponentProperty("DropMe", "highlightColor", "Assembly-CSharp");
             Assert.AreNotEqual(color1,color2);
-            altDriver.FindObject(By.NAME,"Drop Image").PointerExitObject();
+            altDriver.FindObject(By.NAME,"Drop Image").PointerExit();
             var color3 = altObject.GetComponentProperty("DropMe", "highlightColor", "Assembly-CSharp");
             Assert.AreNotEqual(color3, color2);
             Assert.AreEqual(color1,color3);
@@ -4516,10 +4516,10 @@ None
         {
             var altObject = altDriver.FindObject(By.NAME,"Drop Image");
             var color1 = altObject.GetComponentProperty("DropMe", "highlightColor", "Assembly-CSharp"));
-            altDriver.FindObject(By.NAME,"Drop Image").PointerEnterObject();
+            altDriver.FindObject(By.NAME,"Drop Image").PointerEnter();
             var color2 = altObject.GetComponentProperty("DropMe", "highlightColor", "Assembly-CSharp"));
             Assert.AreNotEqual(color1,color2);
-            altDriver.FindObject(By.NAME,"Drop Image").PointerExitObject();
+            altDriver.FindObject(By.NAME,"Drop Image").PointerExit();
             var color3 = altObject.GetComponentProperty("DropMe", "highlightColor", "Assembly-CSharp"));
             Assert.AreNotEqual(color3, color2);
             Assert.AreEqual(color1,color3);


### PR DESCRIPTION
In this PR:
- Updated in `AltObject.cs` the `PointerDown/Up/Enter/Exit` commands and used the `Obsolete` attribute for the deprecated commands
- Updated the C# tests using the above commands
- Updated the examples in the documentation for all languages for the above commands (Python and Java examples used old commands that were updated sometime before)