### PR TITLE
Syntax inconsistencies in the robot `AltTesterLibrary` examples

### DIFF
--- a/Bindings~/robot/src/AltTesterLibrary/AltTesterKeywords.py
+++ b/Bindings~/robot/src/AltTesterLibrary/AltTesterKeywords.py
@@ -59,9 +59,9 @@ class AltTesterKeywords(object):
 
         Example:
 
-        | ${altDriver}= | Initialize AltDriver  | 127.0.0.1  |  15001
+        | ${altDriver}= | Initialize AltDriver | 127.0.0.1 | 15001
 
-        | ${altDriver}= | Initialize AltDriver  | platform="Android"
+        | ${altDriver}= | Initialize AltDriver | platform="Android"
 
         """
         self._driver = AltDriver(
@@ -82,7 +82,7 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Stop AltDriver
+        | Stop AltDriver
         """
         self._driver.stop()
 
@@ -91,7 +91,7 @@ class AltTesterKeywords(object):
 
         Example:
 
-        ${timeout}= | Get Command Response Timeout
+        | ${timeout}= | Get Command Response Timeout
         """
         return self._driver.get_command_response_timeout()
 
@@ -104,7 +104,7 @@ class AltTesterKeywords(object):
 
         Set Command Response Timeout to 30 seconds.
 
-        Set Command Response Timeout | 30
+        | Set Command Response Timeout | 30
         """
         self._driver.set_command_response_timeout(timeout)
 
@@ -115,7 +115,7 @@ class AltTesterKeywords(object):
 
         Example:
         
-        Enable Loguru Logger alttester
+        | Enable Loguru Logger | alttester
         """
         logger.enable(logger_name)
 
@@ -126,7 +126,7 @@ class AltTesterKeywords(object):
 
         Example:
        
-        Disable Loguru Logger alttester
+        | Disable Loguru Logger | alttester
         """
         logger.disable(logger_name)
 
@@ -141,7 +141,7 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Reverse Port Forwarding Android     device_port=15500
+        | Reverse Port Forwarding Android | device_port=15500
         """
         AltReversePortForwarding.reverse_port_forwarding_android(
             device_port, local_port, device_id)
@@ -155,7 +155,7 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Remove Reverse Port Forwarding Android     device_port=15500
+        | Remove Reverse Port Forwarding Android | device_port=15500
         """
         AltReversePortForwarding.remove_reverse_port_forwarding_android(
             device_port, device_id)
@@ -165,7 +165,7 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Remove All Reverse Port Forwardings Android
+        | Remove All Reverse Port Forwardings Android
         """
         AltReversePortForwarding.remove_all_reverse_port_forwardings_android()
 
@@ -189,7 +189,7 @@ class AltTesterKeywords(object):
 
         Find Object by PATH
 
-        | ${logo}= | Find Object | PATH | //Canvas//Logo |  enabled=${False}
+        | ${logo}= | Find Object | PATH | //Canvas//Logo | enabled=${False}
         """
         return self._driver.find_object(self.get_by_enum(locator_strategy), locator,
                                         camera_by=self.get_by_enum(camera_by),
@@ -197,7 +197,7 @@ class AltTesterKeywords(object):
 
     def find_objects(self, locator_strategy,
                      locator, camera_by="NAME", camera_value="", enabled=True):
-        """Finds all objects in the scene that respects the given criteria.
+        """Finds all objects in the scene that respect the given criteria.
 
         `locator_strategy` one of the following: ID, NAME, PATH, LAYER,
         COMPONENT, TAG, TEXT.
@@ -215,7 +215,7 @@ class AltTesterKeywords(object):
 
         Find Objects by PATH
 
-        | ${logo}= | Find Objects | PATH | //Canvas//Logo |  enabled=${False} 
+        | ${logo}= | Find Objects | PATH | //Canvas//Logo | enabled=${False} 
         """
         return self._driver.find_objects(self.get_by_enum(locator_strategy), locator,
                                          camera_by=self.get_by_enum(camera_by),
@@ -241,7 +241,7 @@ class AltTesterKeywords(object):
 
         Find Object Which Contains in Text
 
-        | ${logo}= | Find Object Which Contains | TEXT | Logo |  enabled=${False} 
+        | ${logo}= | Find Object Which Contains | TEXT | Logo | enabled=${False} 
         """
         return self._driver.find_object_which_contains(self.get_by_enum(locator_strategy), locator,
                                                        camera_by=self.get_by_enum(
@@ -250,7 +250,7 @@ class AltTesterKeywords(object):
 
     def find_objects_which_contain(self, locator_strategy,
                                    locator, camera_by="NAME", camera_value="", enabled=True):
-        """Finds all objects in the scene that respects the given criteria.
+        """Finds all objects in the scene that respect the given criteria.
 
         `locator_strategy` one of the following: ID, NAME, PATH, LAYER,
         COMPONENT, TAG, TEXT.
@@ -268,7 +268,7 @@ class AltTesterKeywords(object):
 
         Find Objects Which Contain in Text
 
-        | ${logo}= | Find Objects Which Contain | TEXT | Logo |  enabled=${False} 
+        | ${logo}= | Find Objects Which Contain | TEXT | Logo | enabled=${False} 
         """
         return self._driver.find_objects_which_contain(self.get_by_enum(locator_strategy), locator,
                                                        camera_by=self.get_by_enum(
@@ -284,14 +284,15 @@ class AltTesterKeywords(object):
 
         Find Object at coordinates [20, 20].
 
-        | ${coordinates}  | = | Create List   ${20}   ${20}
+        | ${coordinates}= | Create List | ${20} | ${20}
 
-        | ${object}=      | Find Object At Coordinates | ${coordinates}
+        | ${object}= | Find Object At Coordinates | ${coordinates}
+        
         """
         return self._driver.find_object_at_coordinates(coordinates)
 
     def get_all_elements(self, camera_by="NAME", camera_value="", enabled=True):
-        """Returns information about every objects loaded in the currently loaded scenes. This also means objects that
+        """Returns information about every object loaded in the currently loaded scenes. This also means objects that
         are set as DontDestroyOnLoad.
 
         `camera_by` one of the following: ID, NAME, PATH, LAYER,
@@ -372,8 +373,7 @@ class AltTesterKeywords(object):
 
     def wait_for_object_to_not_be_present(self, locator_strategy,
                                           locator, camera_by="NAME", camera_value="", timeout=DEFAULT_WAIT, interval=0.5, enabled=True):
-        """Waits until the object in the scene that respects the given criteria is no longer in the scene or until
-        timeout limit is reached.
+        """Waits until the object in the scene that respects the given criteria is no longer in the scene or until the timeout limit is reached.
 
         `locator_strategy` one of the following: ID, NAME, PATH, LAYER,
         COMPONENT, TAG, TEXT
@@ -455,7 +455,7 @@ class AltTesterKeywords(object):
 
         Press Keys A and B Down
 
-        | ${keys} | = | Create List | A | B
+        | ${keys}=  | Create List | A | B
 
         | Keys Down | ${keys}
         """
@@ -477,7 +477,7 @@ class AltTesterKeywords(object):
 
         Press Key A Up
 
-        Key Up | A
+        | Key Up | A
         """
         try:
             self._driver.key_up(getattr(AltKeyCode, key_code))
@@ -494,9 +494,9 @@ class AltTesterKeywords(object):
 
         Press Key A and B Up
 
-        | ${keys} | = | Create List | A | B
+        | ${keys}= | Create List | A | B
 
-        Keys Up    | ${keys}
+        | Keys Up  | ${keys}
         """
         list = []
         for key in key_codes:
@@ -520,7 +520,7 @@ class AltTesterKeywords(object):
 
         Hold Button for 1 second
 
-        | ${coordinates} | = | Create List | 20 | 20
+        | ${coordinates}= | Create List | 20 | 20
 
         | Hold Button | ${coordinates} | duration=1
         """
@@ -531,7 +531,7 @@ class AltTesterKeywords(object):
 
         coordinates : The screen coordinates.
 
-        duration : The time measured in seconds to move the mouse from current position to the set location. Default value is``0.1``
+        duration : The time measured in seconds to move the mouse from the current position to the set location. Default value is``0.1``
 
         wait : If set wait for command to finish. Default value is ``True``.
 
@@ -539,7 +539,7 @@ class AltTesterKeywords(object):
 
         Move Mouse for 1 second and don't wait to finish.
 
-        | ${coordinates} | = | Create List | 100 | 100
+        | ${coordinates}= | Create List | 100 | 100
 
         | Move Mouse | ${coordinates} | duration=1 | wait=${False}
         """
@@ -584,7 +584,7 @@ class AltTesterKeywords(object):
 
         Press Keys Mouse0 and Mouse1 for 1 second.
 
-        | ${keys} | = | Create List | Mouse0 | Mouse1
+        | ${keys}= | Create List | Mouse0 | Mouse1
 
         | Press Keys | ${keys} | duration=1
         """
@@ -646,7 +646,7 @@ class AltTesterKeywords(object):
 
         positions : A list of positions on the screen where the swipe be made.
 
-        duration : The time measured in seconds to swipe from first position to the last position. Default value is ``0.1``.
+        duration : The time measured in seconds to swipe from the first position to the last position. Default value is ``0.1``.
 
         wait : If set wait for command to finish. Default value is ``True``.
 
@@ -662,12 +662,12 @@ class AltTesterKeywords(object):
 
         | ${positions}= | Create List | ${position1} | ${position2} | ${position3}
 
-        | Multipoint Swipe| ${positions} | duration=1 | wait=${False}
+        | Multipoint Swipe | ${positions} | duration=1 | wait=${False}
         """
         self._driver.multipoint_swipe(positions, duration=duration, wait=wait)
 
     def begin_touch(self, coordinates):
-        """Simulates starting of a touch on the screen.
+        """Simulates the starting of a touch on the screen.
 
         coordinates : The screen coordinates.
 
@@ -693,18 +693,18 @@ class AltTesterKeywords(object):
 
         Move Touch at coodinates [20, 20]
 
-        ${initila_coordinates}= | Create List | 10 | 10
+        | ${initial_coordinates}= | Create List | 10 | 10
 
-        ${finger_id}= | Begin Touch | ${initila_coordinates}
+        | ${finger_id}= | Begin Touch | ${initial_coordinates}
 
         | ${coordinates}= | Create List | 20 | 20
 
-        | Move Touch   | ${finger_id} | ${coordinates}
+        | Move Touch | ${finger_id} | ${coordinates}
         """
         self._driver.move_touch(finger_id, coordinates)
 
     def end_touch(self, finger_id):
-        """Simulates ending of a touch on the screen. This command will destroy the touch making it no longer usable to
+        """Simulates the ending of a touch on the screen. This command will destroy the touch making it no longer usable to
         other movements.
 
         finger_id : The value returned by ``begin_touch``.
@@ -713,15 +713,15 @@ class AltTesterKeywords(object):
 
         Move Touch from [10, 10] to [20, 20]
 
-        ${initila_coordinates}= | Create List | 10 | 10
+        | ${initial_coordinates}= | Create List | 10 | 10
 
-        ${finger_id}= | Begin Touch | ${initila_coordinates}
+        | ${finger_id}= | Begin Touch | ${initial_coordinates}
 
         | ${coordinates}= | Create List | 20 | 20
 
-        | Move Touch   | ${finger_id} | ${coordinates}
+        | Move Touch | ${finger_id} | ${coordinates}
 
-        | End Touch    | ${finger_id}
+        | End Touch  | ${finger_id}
         """
         self._driver.end_touch(finger_id)
 
@@ -811,7 +811,7 @@ class AltTesterKeywords(object):
     def get_player_pref_key(self, key_name, key_type):
         """Returns the value for a given key from PlayerPrefs.
 
-        key_name : The name of the key to be retrived.
+        key_name : The name of the key to be retrieved.
 
         key_type : The type of the key. One of the following:  Int, String, Float.
 
@@ -831,7 +831,7 @@ class AltTesterKeywords(object):
 
         key_name : The name of the key to be set.
 
-        value : The new value of be set.
+        value : The new value to be set.
 
         key_type : The type of the key.One of the following:  Int, String, Float.
 
@@ -871,7 +871,7 @@ class AltTesterKeywords(object):
 
         Example:
 
-        | ${scene} = | Get Current Scene |
+        | ${scene}= | Get Current Scene |
         """
         return self._driver.get_current_scene()
 
@@ -880,7 +880,7 @@ class AltTesterKeywords(object):
 
         scene_name : The name of the scene to be loaded.
 
-        load_single : Sets the loading mode. If set to ``False`` the scene will be loaded additive, together with the current loaded scenes. Default value is ``True``.
+        load_single : Sets the loading mode. If set to ``False`` the scene will be loaded additive, together with the currently loaded scenes. Default value is ``True``.
 
         Example:
 
@@ -966,7 +966,7 @@ class AltTesterKeywords(object):
                 this: ``"namespace.typeName"``.
 
         method_name : The name of the public method that we want to call. If the method is inside a
-                static property/field to be able to call that method, methodName need to be the following format
+                static property/field to be able to call that method, methodName needs to be in the following format
                 ``"propertyName.MethodName"``.
 
         assembly : The name of the assembly containing the script.
@@ -1048,7 +1048,7 @@ class AltTesterKeywords(object):
                 like this: ``"namespace.typeName"``.
 
         method_name : The name of the public method that we want to call. If the method is inside a
-                static property/field to be able to call that method, methodName need to be the following format
+                static property/field to be able to call that method, methodName needs to be in the following format
                 ``"propertyName.MethodName"``.
 
         assembly : The name of the assembly containing the script.
@@ -1061,9 +1061,9 @@ class AltTesterKeywords(object):
 
         Call method get_text for PlayButton
 
-        | ${object}=   | Find Object | PATH | //PlayButton
+        | ${object}= | Find Object | PATH | //PlayButton
 
-        | ${text} =    | Call Component Method | ${object} | UnityEngine.UI.Text | get_text | UnityEngine.UI
+        | ${text}=   | Call Component Method | ${object} | UnityEngine.UI.Text | get_text | UnityEngine.UI
         """
         return alt_object.call_component_method(component_name, method_name, assembly, parameters=parameters, type_of_parameters=type_of_parameters)
 
@@ -1087,11 +1087,11 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Get Screen Position for Capsule object.
+        Get Screen Position for the Capsule object.
 
-        | ${object}=   | Find Object | NAME | Capsule
+        | ${object}=    | Find Object | NAME | Capsule
 
-        | ${positions} =    | Get Screen Position | ${object}
+        | ${positions}= | Get Screen Position | ${object}
         """
         return alt_object.get_screen_position()
 
@@ -1101,11 +1101,11 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Get World Position for Capsule object.
+        Get World Position for the Capsule object.
 
-        | ${object}=   | Find Object | NAME | Capsule
+        | ${object}=    | Find Object | NAME | Capsule
 
-        | ${positions} =    | Get World Position | ${object}
+        | ${positions}= | Get World Position | ${object}
         """
         return alt_object.get_world_position()
 
@@ -1115,11 +1115,11 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Get Parent for Capsule object.
+        Get Parent for the Capsule object.
 
-        | ${object}=   | Find Object | NAME | Capsule
+        | ${object}= | Find Object | NAME | Capsule
 
-        | ${parent} =    | Get Parent | ${object}
+        | ${parent}= | Get Parent | ${object}
         """
         return alt_object.get_parent()
 
@@ -1129,11 +1129,11 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Get All Components for Capsule object.
+        Get All Components for the Capsule object.
 
-        | ${object}=   | Find Object | NAME | Capsule
+        | ${object}=     | Find Object | NAME | Capsule
 
-        | ${components} =    | Get All Components | ${object}
+        | ${components}= | Get All Components | ${object}
         """
         return alt_object.get_all_components()
 
@@ -1164,9 +1164,9 @@ class AltTesterKeywords(object):
 
         Wait for property TestBool from Capsule
 
-        | ${object}=   | Find Object | NAME | Capsule
+        | ${object}= | Find Object | NAME | Capsule
 
-        | ${result} =    | Wait For Component Property | ${object} | AltExampleScriptCapsule | TestBool | ${True} | Assembly-CSharp
+        | ${result}= | Wait For Component Property | ${object} | AltExampleScriptCapsule | TestBool | ${True} | Assembly-CSharp
         """
         return alt_object.wait_for_component_property(component_name, property_name, property_value, assembly,timeout=timeout, interval=interval, get_property_as_string=get_property_as_string)
 
@@ -1188,11 +1188,11 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Get property arrayOfInts for Capsule .
+        Get property arrayOfInts for Capsule.
 
-        | ${object}=       | Find Object | NAME | Capsule
+        | ${object}=   | Find Object | NAME | Capsule
 
-        | ${property} =    | Get Component Property| ${object} | Capsule | arrayOfInts | ${True} | Assembly-CSharp
+        | ${property}= | Get Component Property | ${object} | Capsule | arrayOfInts | ${True} | Assembly-CSharp
 
         """
         return alt_object.get_component_property(component_name, property_name, assembly, max_depth=max_depth)
@@ -1213,11 +1213,11 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Set property stringToSetFromTests for Capsule .
+        Set property stringToSetFromTests for Capsule.
 
-        | ${object}=       | Find Object | NAME | Capsule
+        | ${object}=             | Find Object | NAME | Capsule
 
-        | Set Component Property| ${object} | Capsule | stringToSetFromTests | Assembly-CSharp | 2
+        | Set Component Property | ${object} | Capsule | stringToSetFromTests | Assembly-CSharp | 2
         """
         alt_object.set_component_property(
             component_name, property_name, assembly, value)
@@ -1231,24 +1231,24 @@ class AltTesterKeywords(object):
 
         Get text for CapsuleInfo.
 
-        | ${object}=    | Find Object | NAME | CapsuleInfo
+        | ${object}= | Find Object | NAME | CapsuleInfo
 
-        | ${text}=      | Get Text | ${object}
+        | ${text}=   | Get Text | ${object}
         """
         return alt_object.get_text()
 
     def get_object_name(self, alt_object: AltObject):
         """Returns name for alt_object.
 
-        alt_object : The AltObject for which we want to get name.
+        alt_object : The AltObject for which we want to get the name.
 
         Example:
 
         Get Object Name for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}= | Find Object | PATH | //CapsuleInfo
 
-        | ${name}=      | Get Object Name | ${object}
+        | ${name}=   | Get Object Name | ${object}
         """
         return alt_object.name
 
@@ -1261,9 +1261,9 @@ class AltTesterKeywords(object):
 
         Get Object Id for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}= | Find Object | PATH | //CapsuleInfo
 
-        | ${id}=      | Get Object Id | ${object}
+        | ${id}=     | Get Object Id | ${object}
         """
         return alt_object.id
 
@@ -1276,9 +1276,9 @@ class AltTesterKeywords(object):
 
         Get Object X for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}=  | Find Object | PATH | //CapsuleInfo
 
-        | ${x_param}=   | Get Object X | ${object}
+        | ${x_param}= | Get Object X | ${object}
         """
         return alt_object.x
 
@@ -1291,9 +1291,9 @@ class AltTesterKeywords(object):
 
         Get Object Y for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}=  | Find Object | PATH | //CapsuleInfo
 
-        | ${y_param}=   | Get Object Y | ${object}
+        | ${y_param}= | Get Object Y | ${object}
         """
         return alt_object.y
 
@@ -1306,9 +1306,9 @@ class AltTesterKeywords(object):
 
         Get Object Z for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}=  | Find Object | PATH | //CapsuleInfo
 
-        | ${z_param}=   | Get Object Z | ${object}
+        | ${z_param}= | Get Object Z | ${object}
         """
         return alt_object.z
 
@@ -1321,9 +1321,9 @@ class AltTesterKeywords(object):
 
         Get Object MobileY for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}=  | Find Object | PATH | //CapsuleInfo
 
-        | ${mobileY}=   | Get Object MobileY | ${object}
+        | ${mobileY}= | Get Object MobileY | ${object}
         """
         return alt_object.mobileY
 
@@ -1336,9 +1336,9 @@ class AltTesterKeywords(object):
 
         Get Object Type for CapsuleInfo.
 
-        | ${object}=  | Find Object | PATH | //CapsuleInfo
+        | ${object}= | Find Object | PATH | //CapsuleInfo
 
-        | ${type}=    | Get Object Type | ${object}
+        | ${type}=   | Get Object Type | ${object}
         """
         return alt_object.type
 
@@ -1351,9 +1351,9 @@ class AltTesterKeywords(object):
 
         Get Object Enabled for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}=  | Find Object | PATH | //CapsuleInfo
 
-        | ${enabled}=   | Get Object Enabled | ${object}
+        | ${enabled}= | Get Object Enabled | ${object}
         """
         return alt_object.enabled
 
@@ -1366,9 +1366,9 @@ class AltTesterKeywords(object):
 
         Get Object WorldX for CapsuleInfo.
 
-        | ${object}=   | Find Object | PATH | //CapsuleInfo
+        | ${object}= | Find Object | PATH | //CapsuleInfo
 
-        | ${worldX}=   | Get Object WorldX | ${object}
+        | ${worldX}= | Get Object WorldX | ${object}
         """
         return alt_object.worldX
 
@@ -1381,9 +1381,9 @@ class AltTesterKeywords(object):
 
         Get Object WorldY for CapsuleInfo.
 
-        | ${object}=   | Find Object | PATH | //CapsuleInfo
+        | ${object}= | Find Object | PATH | //CapsuleInfo
 
-        | ${worldY}=   | Get Object WorldY | ${object}
+        | ${worldY}= | Get Object WorldY | ${object}
         """
         return alt_object.worldY
 
@@ -1396,9 +1396,9 @@ class AltTesterKeywords(object):
 
         Get Object WorldZ for CapsuleInfo.
 
-        | ${object}=   | Find Object | PATH | //CapsuleInfo
+        | ${object}= | Find Object | PATH | //CapsuleInfo
 
-        | ${worldZ}=   | Get Object WorldZ | ${object}
+        | ${worldZ}= | Get Object WorldZ | ${object}
         """
         return alt_object.worldZ
 
@@ -1411,9 +1411,9 @@ class AltTesterKeywords(object):
 
         Get Object IdCamera for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}=   | Find Object | PATH | //CapsuleInfo
 
-        | ${idCamera}=  | Get Object IdCamera | ${object}
+        | ${idCamera}= | Get Object IdCamera | ${object}
         """
         return alt_object.idCamera
 
@@ -1426,9 +1426,9 @@ class AltTesterKeywords(object):
 
         Get Object TransformParentId for CapsuleInfo.
 
-        | ${object}=    | Find Object | PATH | //CapsuleInfo
+        | ${object}=            | Find Object | PATH | //CapsuleInfo
 
-        | ${transformParentId}=  | Get Object TransformParentId | ${object}
+        | ${transformParentId}= | Get Object TransformParentId | ${object}
         """
         return alt_object.transformParentId
 
@@ -1441,9 +1441,9 @@ class AltTesterKeywords(object):
 
         Get Object TransformId for CapsuleInfo.
 
-        | ${object}=       | Find Object | PATH | //CapsuleInfo
+        | ${object}=      | Find Object | PATH | //CapsuleInfo
 
-        | ${transformId}=  | Get Object TransformId | ${object}
+        | ${transformId}= | Get Object TransformId | ${object}
         """
         return alt_object.transformId
 
@@ -1460,9 +1460,9 @@ class AltTesterKeywords(object):
 
         Set text InputFieldTest for CapsuleInfo.
 
-        | ${object}=    | Find Object | NAME | CapsuleInfo
+        | ${object}= | Find Object | NAME | CapsuleInfo
 
-        | Set Text      | ${object} | InputFieldTest
+        | Set Text   | ${object} | InputFieldTest
         """
         return alt_object.set_text(text, submit=submit)
 
@@ -1481,9 +1481,9 @@ class AltTesterKeywords(object):
 
         Double tap on Capsule.
 
-        | ${object}=    | Find Object | NAME | Capsule
+        | ${object}= | Find Object | NAME | Capsule
 
-        | Tap Object    | ${object} |  count=2
+        | Tap Object | ${object} | count=2
         """
         alt_object.tap(count=count, interval=interval, wait=wait)
 
@@ -1500,11 +1500,11 @@ class AltTesterKeywords(object):
 
         Example:
 
-        Double click on Capsule.
+        Double-click on Capsule.
 
-        | ${object}=    | Find Object | NAME | Capsule
+        | ${object}=   | Find Object | NAME | Capsule
 
-        | Click Object  | ${object} |  count=2
+        | Click Object | ${object} | count=2
         """
         alt_object.click(count=count, interval=interval, wait=wait)
 
@@ -1517,9 +1517,9 @@ class AltTesterKeywords(object):
 
         Pointer Down on Panel.
 
-        | ${object}=    | Find Object | NAME | Panel
+        | ${object}=   | Find Object | NAME | Panel
 
-        | Pointer Down  | ${object} |
+        | Pointer Down | ${object} |
         """
         return alt_object.pointer_down()
 
@@ -1532,9 +1532,9 @@ class AltTesterKeywords(object):
 
         Pointer Up on Panel.
 
-        | ${object}=    | Find Object | NAME | Panel
+        | ${object}= | Find Object | NAME | Panel
 
-        | Pointer Up  | ${object} |
+        | Pointer Up | ${object} |
         """
         return alt_object.pointer_up()
 
@@ -1549,7 +1549,7 @@ class AltTesterKeywords(object):
 
         | ${object}=    | Find Object | NAME | Drop Image
 
-        | Pointer Enter  | ${object} |
+        | Pointer Enter | ${object} |
         """
         return alt_object.pointer_enter()
 
@@ -1562,9 +1562,9 @@ class AltTesterKeywords(object):
 
         Pointer Exit on Drop Image.
 
-        | ${object}=    | Find Object | NAME | Drop Image
+        | ${object}=   | Find Object | NAME | Drop Image
 
-        | Pointer Exit  | ${object} |
+        | Pointer Exit | ${object} |
         """
         return alt_object.pointer_exit()
 


### PR DESCRIPTION
In this PR:
- added the `|` separator in the examples where it wasn't used and also at the beginning of some examples, to be consistent with the majority of all the other examples
- added the `|` separator missing from the `enable_loguru_logger` and `disble_loguru_logger` methods examples
- fixed some typos