### PR TITLE
Fix alt dialog

### DIFF
--- a/Assets/AltTester/Runtime/UI/AltDialog.cs
+++ b/Assets/AltTester/Runtime/UI/AltDialog.cs
@@ -468,7 +468,7 @@ namespace AltTester.AltTesterUnitySDK.UI
                 wasConnected = false;
                 if (responseCode > 4000 && responseCode < 5000)
                 {
-                    isEditing = true;
+                    isEditing = false;
                     stopClientsCalled = false;
                     return;
                 }

--- a/Assets/AltTester/Runtime/UI/AltDialog.cs
+++ b/Assets/AltTester/Runtime/UI/AltDialog.cs
@@ -100,6 +100,7 @@ namespace AltTester.AltTesterUnitySDK.UI
         private bool stopClientsCalled = false;
         private bool beginCommunicationCalled = false;
         private bool isEditing = false;
+        private bool isError = false;
         private bool isCommunicationConnected;
         private bool isLiveUpdateConnected;
         private bool isDriverConnected;
@@ -318,6 +319,7 @@ namespace AltTester.AltTesterUnitySDK.UI
             appId = null;
 
             responseCode = 0;
+            isError = false;
             validateFields();
             if (isDataValid)
                 isEditing = false;
@@ -468,7 +470,7 @@ namespace AltTester.AltTesterUnitySDK.UI
                 wasConnected = false;
                 if (responseCode > 4000 && responseCode < 5000)
                 {
-                    isEditing = false;
+                    isEditing = true;
                     stopClientsCalled = false;
                     return;
                 }
@@ -521,7 +523,10 @@ namespace AltTester.AltTesterUnitySDK.UI
         {
             responseCode = code;
             if (code >= 4000 && code < 5000)
+            {
+                isError = true;
                 updateQueue.ScheduleResponse(() => setMessage(reason, errorColor, true));
+            }
             updateQueue.ScheduleResponse(() => stopClients());
         }
 
@@ -568,7 +573,7 @@ namespace AltTester.AltTesterUnitySDK.UI
         private void onConnect()
         {
             wasConnected = true;
-            if (!isDriverConnected)
+            if (!isDriverConnected && !isError)
             {
                 string message = createMessage();
                 setMessage(message, color: successColor, visible: true);


### PR DESCRIPTION
If a GameEngineUnsupported error is returned from AltServer when the Restart button is pressed, the AltDialog does not show the error anymore, instead, the Editing message appears. 