### PR TITLE
[FAQ] Update info about the oldest Unity version supported + Update first section in FAQ

### DIFF
--- a/Docs/source/pages/faq-troubleshooting.md
+++ b/Docs/source/pages/faq-troubleshooting.md
@@ -3,7 +3,7 @@
 <details>
 <summary> On what platforms can I run tests with AltTester® Unity SDK? </summary>
 <br>
-PC, Mac, Android, iOS, WebGL, Consoles and Unity Editor.
+PC, Mac, Android, iOS, WebGL, Console and Unity Editor.
 </details>
 <br>
 

--- a/Docs/source/pages/faq-troubleshooting.md
+++ b/Docs/source/pages/faq-troubleshooting.md
@@ -3,7 +3,7 @@
 <details>
 <summary> On what platforms can I run tests with AltTester® Unity SDK? </summary>
 <br>
-PC, Mac, Android, iOS and Unity Editor; support for WebGL and Consoles is work in progress.
+PC, Mac, Android, iOS, WebGL, Consoles and Unity Editor.
 </details>
 <br>
 

--- a/Docs/source/pages/faq-troubleshooting.md
+++ b/Docs/source/pages/faq-troubleshooting.md
@@ -24,7 +24,7 @@ Yes, AltTester® Unity SDK can be used alongside Appium. Appium allows you to ac
 <details>
 <summary> What versions of Unity does AltTester® Unity SDK work with? </summary>
 <br>
-AltTester® Unity SDK works with Unity 2020.3.0 or higher. If you encounter any issues we'd like to hear about them. You can <a href="contributing.html#did-you-find-a-bug">raise an issue</a> or join our community on <a href="https://discord.gg/Ag9RSuS">Discord</a>.
+AltTester® Unity SDK works with Unity 2021.3 LTS or higher. We no longer support Unity 2020.3 LTS as it has reached its End-of-Support from Unity and there was also a limitation for the IL2CPP builds. If you encounter any issues we'd like to hear about them. You can <a href="contributing.html#did-you-find-a-bug">raise an issue</a> or join our community on <a href="https://discord.gg/Ag9RSuS">Discord</a>.
 </details>
 <br>
 


### PR DESCRIPTION
In this PR:
- docs fix for [[FAQ] Update info about the oldest Unity version supported](https://github.com/alttester/AltTester-Unity-SDK/issues/1685)
- docs fix for  [Update first section in FAQ](https://github.com/alttester/AltTester-Unity-SDK/issues/1691)  