### PR TITLE
Remove .meta files for non-existent folders

### DIFF
--- a/Assets/AltTester/Editor/Scripts/AltPlatforms.meta
+++ b/Assets/AltTester/Editor/Scripts/AltPlatforms.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 983d1e58070668049bf6c097703f2b5a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AltTester/Examples/Test/Editor/Driver.meta
+++ b/Assets/AltTester/Examples/Test/Editor/Driver.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 574d1c3b6c3f47247bfe5ab30f2f8cb8
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AltTester/Runtime/AltDriver/Proxy/Plugins/iOS/AltProxyFinder/Editor.meta
+++ b/Assets/AltTester/Runtime/AltDriver/Proxy/Plugins/iOS/AltProxyFinder/Editor.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 620804d8d59bf48b9a6a23fd8a83a35a
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AltTester/Runtime/AltDriver/Proxy/Plugins/iOS/ProxyFinder.meta
+++ b/Assets/AltTester/Runtime/AltDriver/Proxy/Plugins/iOS/ProxyFinder.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: d4fd909731ee4408b88e34820f4cdb73
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/AltTester/Runtime/UnityStruct.meta
+++ b/Assets/AltTester/Runtime/UnityStruct.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3ac23316d323ece4395b5f0913d1b24c
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Removes some .meta files for folders that don't exist. These trigger warnings inside Unity when using the package.

![Screenshot 2024-11-01 at 10 53 51](https://github.com/user-attachments/assets/a70582e9-284b-4211-ae4c-7640b1c8dd0d)
