### PR TITLE
Use the proper exception name instead of MaxNoOfConnectionsDriversExceeded

### DIFF
--- a/Bindings~/python/alttester/_websocket.py
+++ b/Bindings~/python/alttester/_websocket.py
@@ -219,7 +219,7 @@ class WebsocketConnection:
                 raise exceptions.MultipleDriversTryingToConnectException(
                     reason)
             if close_message[0] == 4009:
-                raise exceptions.MaxNoOfConnectionsDriversExceeded(
+                raise exceptions.MaxNoOfConnectionsDriversExceededException(
                     reason)
 
             raise exceptions.ConnectionError(


### PR DESCRIPTION
This change
- fixes the typo ("MaxNoOfConnectionsDriversExceeded" → "MaxNoOfConnectionsDriversExceededException")