### PR TITLE
Fix incorrect assembly name in link.xml

### DIFF
--- a/Assets/AltTester/link.xml
+++ b/Assets/AltTester/link.xml
@@ -11,7 +11,7 @@
         <type fullname="AltTester.*" preserve="all" />
     </assembly>
 
-    <assembly fullname="AltTester.AltTesterSDK.Driver">
+    <assembly fullname="AltTester.AltTesterUnitySDK.Driver">
         <type fullname="AltTester.*" preserve="all" />
     </assembly>
 </linker>


### PR DESCRIPTION
The assembly name in link.xml was incorrect, which caused Unity to strip out necessary objects during code stripping. This change corrects the name to ensure those objects are properly preserved.
