### PR TITLE
Fix Robot Framework library scope to allow multiple drivers per run

### DIFF
--- a/Bindings~/robot/src/AltTesterLibrary/__init__.py
+++ b/Bindings~/robot/src/AltTesterLibrary/__init__.py
@@ -33,5 +33,5 @@ class AltTesterLibrary(AltTesterKeywords):
 
     """
 
-    ROBOT_LIBRARY_SCOPE = 'GLOBAL'
+    ROBOT_LIBRARY_SCOPE = 'SUITE'
     ROBOT_LIBRARY_VERSION = __version__

--- a/Docs/source/pages/get-started.md
+++ b/Docs/source/pages/get-started.md
@@ -536,6 +536,19 @@ AltTester® package contains AltDriver class used to connect to the instrumented
 
             - After running the test the Robot will generate 3 files: ``report.html``, ``log.html`` and ``output.xml`` - the  html files can be opened in the browser and for every test in ``log.html`` there will be a status highlight, the keywords used, as well as a potential error that might have occured during the test
 
+        **Connecting to multiple app instances:**
+            - To drive more than one instrumented app from the same suite, import ``AltTesterLibrary`` once per instance using ``WITH NAME`` and initialize each alias with its own ``app_name`` (and ``port`` if needed). Each alias holds its own driver, so keywords stay isolated.
+            .. code-block:: robot
+
+                *** Settings ***
+                Library    AltTesterLibrary    WITH NAME    P1
+                Library    AltTesterLibrary    WITH NAME    P2
+
+                *** Test Cases ***
+                Two Players Connect Independently
+                    P1.Initialize Altdriver    host=127.0.0.1    port=13000    app_name=player-one
+                    P2.Initialize Altdriver    host=127.0.0.1    port=13000    app_name=player-two
+                    [Teardown]    Run Keywords    P1.Stop Altdriver    AND    P2.Stop Altdriver
 
         Example test file:
 


### PR DESCRIPTION
## Summary
- Change `ROBOT_LIBRARY_SCOPE` from `'GLOBAL'` to `'SUITE'` in `Bindings~/robot/src/AltTesterLibrary/__init__.py` so each `WITH NAME` alias gets its own `AltTesterLibrary` instance instead of silently sharing one driver across aliases.
- Add a "Connecting to multiple app instances" subsection to the Robot Framework tab in `Docs/source/pages/get-started.md` showing the `WITH NAME P1`/`WITH NAME P2` pattern.

Fixes #1965.

## Behavior change
- Existing single-library, single-suite usage: no observable change — each suite already calls `Initialize Altdriver` in `Suite Setup` and `Stop Altdriver` in `Suite Teardown`.
- Multi-suite runs that relied on a driver leaking from one suite into the next without re-initializing will need to add a per-suite `Suite Setup`/`Suite Teardown` (this was the symptom the ticket calls out).
- The intended `WITH NAME` multi-driver case now works as expected — worth mentioning in the GitHub release notes.

## Test plan
- [ ] Run the in-repo Robot suites in `Bindings~/robot/tests/` against an instrumented build to confirm the existing single-library single-suite flow is unchanged.
- [ ] Run a two-alias smoke suite (the snippet now in the docs) against two instrumented app instances and verify `P1.*` and `P2.*` keywords hit independent drivers.